### PR TITLE
upgrade prophet to 1.1 which is way easier to install

### DIFF
--- a/.github/workflows/test-app.yml
+++ b/.github/workflows/test-app.yml
@@ -19,10 +19,9 @@ jobs:
         python-version: "3.8"
     - name: Install dependencies
       run: |
-        python -m pip install wheel
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest
-        python -m pip install .
+        python -m pip install --no-use-pep517 .
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/test-app.yml
+++ b/.github/workflows/test-app.yml
@@ -14,14 +14,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: "3.8"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest
-        python -m pip install --no-use-pep517 .
+        python -m pip install .
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/test-app.yml
+++ b/.github/workflows/test-app.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.8
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v4
       with:
         python-version: "3.8"
     - name: Install dependencies

--- a/.github/workflows/test-app.yml
+++ b/.github/workflows/test-app.yml
@@ -19,10 +19,10 @@ jobs:
         python-version: "3.8"
     - name: Install dependencies
       run: |
-        # HACK: we aren't ready for pip 23.1 yet
-        python -m pip install --upgrade 'pip<23.1'
-        pip install flake8 pytest
-        pip install .
+        python -m pip install wheel
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest
+        python -m pip install .
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ Flask==2.0.2
 fonttools==4.29.1
 gunicorn==20.1.0
 hijri-converter==2.2.2
-holidays==0.12
+holidays==0.13
 idna==3.3
 itsdangerous==2.0.1
 Jinja2==3.0.3
@@ -26,7 +26,7 @@ numpy==1.21
 packaging==21.3
 pandas==1.4.0
 Pillow==9.0.1
-prophet==1.0.1
+prophet==1.1
 PyMeeus==0.5.11
 pyparsing==3.0.7
 python-dateutil==2.8.2


### PR DESCRIPTION
this also lets us use latest pip

can't even build prophet 1.0.1 with pip<23.1 locally so... i believe this would be a welcome change in general

there isn't much difference between the two versions beyond the fact that they offer prebuilt wheels
https://github.com/facebook/prophet/releases/tag/v1.1
edit: i stand corrected - some pytest failures are related to this, lol