### PR TITLE
(OPS-3797) Set up model retrieval for GHA and Cloud Build

### DIFF
--- a/.github/workflows/test-app.yml
+++ b/.github/workflows/test-app.yml
@@ -46,6 +46,6 @@ jobs:
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@v1
     - name: Fetch models
-      run: gcloud storage cp gs://tmp_tillman/models/* ./models/
+      run: gcloud storage cp -r gs://tmp_tillman/models/* ./models/
     - name: Test building the Docker image
       run: docker build . --file Dockerfile --tag seer:$(date +%s)

--- a/.github/workflows/test-app.yml
+++ b/.github/workflows/test-app.yml
@@ -10,6 +10,10 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    # required for google auth
+    permissions:
+	contents: "read"
+	id-token: "write"
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test-app.yml
+++ b/.github/workflows/test-app.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
@@ -31,5 +31,14 @@ jobs:
     - name: Test with pytest
       run: |
         pytest
+    - id: 'auth'
+      uses: google-github-actions/auth@v1
+      with:
+        workload_identity_provider: 'projects/868781662168/locations/global/workloadIdentityPools/prod-github/providers/github-oidc-pool'
+        service_account: 'gha-seer-models@sac-prod-sa.iam.gserviceaccount.com'
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@v1
+    - name: Fetch models
+      run: gcloud storage cp gs://tmp_tillman/models/* ./models/
     - name: Test building the Docker image
       run: docker build . --file Dockerfile --tag seer:$(date +%s)

--- a/.github/workflows/test-app.yml
+++ b/.github/workflows/test-app.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     # required for google auth
     permissions:
-	contents: "read"
-	id-token: "write"
+      contents: "read"
+      id-token: "write"
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test-app.yml
+++ b/.github/workflows/test-app.yml
@@ -36,6 +36,9 @@ jobs:
       with:
         workload_identity_provider: 'projects/868781662168/locations/global/workloadIdentityPools/prod-github/providers/github-oidc-pool'
         service_account: 'gha-seer-models@sac-prod-sa.iam.gserviceaccount.com'
+        token_format: 'id_token'
+        id_token_audience: '610575311308-9bsjtgqg4jm01mt058rncpopujgk3627.apps.googleusercontent.com'
+        id_token_include_email: true
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@v1
     - name: Fetch models

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,7 @@ RUN pip install --upgrade pip==21.3.1 &&\
 COPY src/ src/
 RUN pip install --default-timeout=120 .
 
+COPY models/ models/
+
 # The number of gunicorn workers is selected by ops based on k8s configuration.
 CMD exec gunicorn --bind :$PORT --worker-class sync --threads 1 --timeout 0 src.seer.seer:app

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,7 @@
 steps:
+- name: 'gcr.io/cloud-builders/gsutil'
+  args: ['cp', 'gs://tmp_tillman/models/*', './models']
+
 - name: 'gcr.io/cloud-builders/docker'
   args: [ 'build', '-t', 'us.gcr.io/sentryio/seer:$COMMIT_SHA', '.' ]
 

--- a/models/.gitignore
+++ b/models/.gitignore
@@ -1,0 +1,1 @@
+# This is a placeholder so that the empty "models" directory exists. We aren't actually ignoring anything in here.


### PR DESCRIPTION
* This creates an empty `models` directory, where model data will eventually go during builds. The `.gitignore` in there is a bit of a hack; Git doesn't add empty directories, but a no-op .gitignore makes the directory not-empty.
* It sets up the GitHub Actions build to fetch files from the designated bucket and copy them into the `models` directory; for this, it uses a GCP service account created for this and limited to the bucket in question
* It sets up the Cloud Build config to fetch files from the designated bucket and copy them into the `models` directory; for this, it uses the default service account for Cloud Build, which will have access to the bucket in question
* It tells the Dockerfile to copy the contents of the `models` directory in this repo into its own `models` directory.

If the code expects models to be someplace else, then we can change names in these four places.