### PR TITLE
fix(cloudbuild): Add recursive flag to cp

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,6 @@
 steps:
 - name: 'gcr.io/cloud-builders/gsutil'
-  args: ['cp', 'gs://tmp_tillman/models/*', './models']
+  args: ['cp', '-r', 'gs://tmp_tillman/models/*', './models']
 
 - name: 'gcr.io/cloud-builders/docker'
   args: [ 'build', '-t', 'us.gcr.io/sentryio/seer:$COMMIT_SHA', '.' ]


### PR DESCRIPTION
#83 successfully added the `gsutil cp` command to `cloudbuild.yaml`, so Cloud Build was able to start copying files. However, I forgot the `-r` flag, which is necessary to recurse through the subdirectories. (D'oh!)