### PR TITLE
fix: Correctly disable midpoint fallback

### DIFF
--- a/src/seer/trend_detection/trend_detector.py
+++ b/src/seer/trend_detection/trend_detector.py
@@ -98,12 +98,13 @@ def find_trends(txns_data, sort_function, zerofilled, allow_midpoint, trend_perc
             change_point = int(datetime.datetime.timestamp(change_point))
             change_index = timestamps.index(change_point)
 
-        #check the midpoint boolean - don't get midpoint of the request period if this boolean is false, midpoint should only be used for trends
-        if not allow_midpoint:
-            continue
-
         # if breakpoint is in the very beginning or no breakpoints are detected, use midpoint analysis instead
         if num_breakpoints == 0 or change_index <= req_start_index + 15 or change_index >= len(timestamps) - 10:
+
+            # check the midpoint boolean - don't get midpoint of the request period if this boolean is false, midpoint should only be used for trends
+            if not allow_midpoint:
+                continue
+
             change_point = (req_start + req_end) // 2
 
 


### PR DESCRIPTION
Only check the allow_midpoint fallback right before the fallback. Having it outside means there will never be a breakpoint when midpoints are disallowed.