### PR TITLE
fix: Fix midpoint fallback, update start/end logic, remove docker build

### DIFF
--- a/.github/workflows/test-app.yml
+++ b/.github/workflows/test-app.yml
@@ -49,5 +49,3 @@ jobs:
       uses: google-github-actions/setup-gcloud@v1
     - name: Fetch models
       run: gcloud storage cp -r gs://tmp_tillman/models/* ./models/
-    - name: Test building the Docker image
-      run: docker build . --file Dockerfile --tag seer:$(date +%s)

--- a/src/seer/trend_detection/trend_detector.py
+++ b/src/seer/trend_detection/trend_detector.py
@@ -98,12 +98,12 @@ def find_trends(txns_data, sort_function, zerofilled, allow_midpoint, trend_perc
             change_point = int(datetime.datetime.timestamp(change_point))
             change_index = timestamps.index(change_point)
 
-        #check the midpoint boolean - don't get midpoint of the request period if this boolean is false, midpoint should only be used for trends
-        if not allow_midpoint:
-            continue
-
         # if breakpoint is in the very beginning or no breakpoints are detected, use midpoint analysis instead
-        if num_breakpoints == 0 or change_index <= req_start_index + 15 or change_index >= len(timestamps) - 10:
+        if num_breakpoints == 0 or change_index <= 5:
+            #check the midpoint boolean - don't get midpoint of the request period if this boolean is false, midpoint should only be used for trends
+            if not allow_midpoint:
+                continue
+
             change_point = (req_start + req_end) // 2
 
 


### PR DESCRIPTION
- removed the docker build step from the github test suite (causing failures due to it running out of storage)
- fixed the midpoint fallback logic
- allow breakpoints at the very end of a timeseries