### PR TITLE
feat: add minimum ms parameter

### DIFF
--- a/src/seer/seer.py
+++ b/src/seer/seer.py
@@ -83,7 +83,7 @@ def breakpoint_trends_endpoint():
                 sort_function,
                 allow_midpoint,
                 min_pct_change,
-                min_ms_change
+                min_change
             )
 
         trends = {"data": [x[1] for x in trend_percentage_list]}

--- a/src/seer/seer.py
+++ b/src/seer/seer.py
@@ -68,14 +68,11 @@ def breakpoint_trends_endpoint():
         data = request.get_json()
         txns_data = data["data"]
 
-        # new format has zerofilled parameter - if it's not being sent to microservice default value is True
-        zerofilled = data.get("zerofilled", True)
-
         sort_function = data.get("sort", "")
-
         allow_midpoint  = data.get("allow_midpoint", "1") == "1"
 
-        lower_limit_trend_percentage = float(data.get('trend_percentage()', 0.1))
+        min_pct_change = float(data.get('trend_percentage()', 0.1))
+        min_ms_change = float(data.get('min_ms_change()', 25.0))
 
         with sentry_sdk.start_span(
             op="cusum.detection",
@@ -84,9 +81,9 @@ def breakpoint_trends_endpoint():
             trend_percentage_list = find_trends(
                 txns_data,
                 sort_function,
-                zerofilled,
                 allow_midpoint,
-                trend_perc=lower_limit_trend_percentage,
+                min_pct_change,
+                min_ms_change
             )
 
         trends = {"data": [x[1] for x in trend_percentage_list]}

--- a/src/seer/seer.py
+++ b/src/seer/seer.py
@@ -72,7 +72,7 @@ def breakpoint_trends_endpoint():
         allow_midpoint  = data.get("allow_midpoint", "1") == "1"
 
         min_pct_change = float(data.get('trend_percentage()', 0.1))
-        min_ms_change = float(data.get('min_ms_change()', 25.0))
+        min_change = float(data.get('min_change()', 0))
 
         with sentry_sdk.start_span(
             op="cusum.detection",

--- a/src/seer/trend_detection/trend_detector.py
+++ b/src/seer/trend_detection/trend_detector.py
@@ -23,7 +23,7 @@ def find_trends(
     sort_function,
     allow_midpoint,
     min_pct_change,
-    min_ms_change,
+    min_change,
     pval=0.01,
 ):
     trend_percentage_list = []

--- a/src/seer/trend_detection/trend_detector.py
+++ b/src/seer/trend_detection/trend_detector.py
@@ -21,11 +21,10 @@ from seer.trend_detection.detectors.cusum_detection import CUSUMDetector
 def find_trends(
     txns_data,
     sort_function,
-    zerofilled,
     allow_midpoint,
-    trend_perc=0.1,
+    min_pct_change,
+    min_ms_change,
     pval=0.01,
-    min_ms_change=25,
 ):
     trend_percentage_list = []
 
@@ -163,7 +162,7 @@ def find_trends(
             (sort_function == "trend_percentage()" or sort_function == "")
             and mu1 <= mu0
             and scipy_t_test.pvalue < pval
-            and abs(trend_percentage - 1) > trend_perc
+            and abs(trend_percentage - 1) > min_pct_change
             and mu0 - mu1 > min_ms_change
         ):
             output_dict["change"] = "improvement"
@@ -174,7 +173,7 @@ def find_trends(
             (sort_function == "-trend_percentage()" or sort_function == "")
             and mu0 <= mu1
             and scipy_t_test.pvalue < pval
-            and abs(trend_percentage - 1) > trend_perc
+            and abs(trend_percentage - 1) > min_pct_change
             and mu1 - mu0 > min_ms_change
         ):
             output_dict["change"] = "regression"

--- a/src/seer/trend_detection/trend_detector.py
+++ b/src/seer/trend_detection/trend_detector.py
@@ -160,7 +160,7 @@ def find_trends(
         # most improved - get only negatively significant trending txns
         if (
             (sort_function == "trend_percentage()" or sort_function == "")
-            and mu1 + min_ms_change <= mu0
+            and mu1 + min_change <= mu0
             and scipy_t_test.pvalue < pval
             and abs(trend_percentage - 1) > min_pct_change
         ):
@@ -170,7 +170,7 @@ def find_trends(
         # if most regressed - get only positively signiificant txns
         elif (
             (sort_function == "-trend_percentage()" or sort_function == "")
-            and mu0 + min_ms_change <= mu1
+            and mu0 + min_change <= mu1
             and scipy_t_test.pvalue < pval
             and abs(trend_percentage - 1) > min_pct_change
         ):

--- a/src/seer/trend_detection/trend_detector.py
+++ b/src/seer/trend_detection/trend_detector.py
@@ -160,10 +160,9 @@ def find_trends(
         # most improved - get only negatively significant trending txns
         if (
             (sort_function == "trend_percentage()" or sort_function == "")
-            and mu1 <= mu0
+            and mu1 + min_ms_change <= mu0
             and scipy_t_test.pvalue < pval
             and abs(trend_percentage - 1) > min_pct_change
-            and mu0 - mu1 > min_ms_change
         ):
             output_dict["change"] = "improvement"
             trend_percentage_list.append((trend_percentage, output_dict))
@@ -171,10 +170,9 @@ def find_trends(
         # if most regressed - get only positively signiificant txns
         elif (
             (sort_function == "-trend_percentage()" or sort_function == "")
-            and mu0 <= mu1
+            and mu0 + min_ms_change <= mu1
             and scipy_t_test.pvalue < pval
             and abs(trend_percentage - 1) > min_pct_change
-            and mu1 - mu0 > min_ms_change
         ):
             output_dict["change"] = "regression"
             trend_percentage_list.append((trend_percentage, output_dict))


### PR DESCRIPTION
- black format trend_detector.py
- add `min_ms_change` parameter with a default value of 25 (miliseconds)
- remove unused `zerofilled` parameter
- make variable names more readable
- remove duplication of default value logic

@udameli @Zylphrex lmk what you guys think makes sense for a default value for `min_ms_change`. Also, we may want to set it to a lower value or remove it for trends so stuff like this still shows up
![image](https://github.com/getsentry/timeseries-analysis-service/assets/8632090/897264f9-f6d2-4da8-9d64-1cfdb17cb187)
