### PR TITLE
chore: allow forced errors and timeouts

### DIFF
--- a/src/seer/seer.py
+++ b/src/seer/seer.py
@@ -1,5 +1,6 @@
 import sentry_sdk
 import os
+import time
 
 from flask import Flask, request
 from sentry_sdk.integrations.flask import FlaskIntegration
@@ -54,6 +55,10 @@ if not os.environ.get("PYTEST_CURRENT_TEST"):
 def def_severity_endpoint():
     try:
         data = request.get_json()
+        if data.get("trigger_error") is not None:
+            return {"oh no": str(e)}, 500
+        elif data.get("trigger_timeout") is not None:
+            time.sleep(0.5)
         severity = embeddings_model.severity_score(data)
         results = {"severity": str(severity)}
         return results


### PR DESCRIPTION
if `trigger_error` is added as a parameter to the POST request, it will return a 500 error
If `trigger_timeout` is added as a paremeter, it will sleep for 500ms and then proceed normally