### PR TITLE
fix(autofix): Fix Github diff truncated files list when embedding for autofix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,8 @@ module = [
     "sentence_transformers.*",
     "scipy.*",
     "openai_multi_tool_use_parallel_patch",
-    "fsspec"
+    "fsspec",
+    "unidiff"
 ]
 ignore_missing_imports = true
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -87,3 +87,4 @@ celery-stubs==0.1.3
 redis==5.0.1
 # deepsparse-nightly==1.7.0.20240103 TODO - fix pydantic conflict
 faiss-cpu==1.7.4
+unidiff==0.7.5

--- a/src/seer/automation/autofix/agent_context.py
+++ b/src/seer/automation/autofix/agent_context.py
@@ -210,7 +210,6 @@ class AgentContext:
         # Hack: We're extracting the authorization and user agent headers from the PyGithub library to get this diff
         # This has to be done because the files list inside the comparison object is limited to only 300 files.
         # We get the entire diff from the diff object returned from the `diff_url`
-        # Pinged this github issue in hopes that the library will implement it: https://github.com/PyGithub/PyGithub/issues/2027
         headers = {
             "Authorization": f"{requester._Requester__auth.token_type} {requester._Requester__auth.token}",  # type: ignore
             "User-Agent": requester._Requester__userAgent,  # type: ignore

--- a/src/seer/automation/autofix/agent_context.py
+++ b/src/seer/automation/autofix/agent_context.py
@@ -9,6 +9,7 @@ from typing import List
 
 import joblib
 import requests
+import sentry_sdk
 import torch
 from github import Auth, Github, GithubIntegration
 from github.GitRef import GitRef
@@ -20,6 +21,7 @@ from llama_index.node_parser import CodeSplitter
 from llama_index.readers import SimpleDirectoryReader
 from llama_index.schema import BaseNode, Document
 from llama_index.storage import StorageContext
+from unidiff import PatchSet
 
 from seer.automation.autofix.types import AutofixAgentsOutput, FileChange
 from seer.automation.autofix.utils import (
@@ -200,12 +202,30 @@ class AgentContext:
 
         return documents, nodes
 
-    def _get_commit_file_diffs(self) -> list[str]:
+    def _get_commit_file_diffs(self) -> tuple[list[str], list[str]]:
         comparison = self.repo.compare(CACHED_COMMIT_SHA, self.base_sha)
 
-        filenames = [f.filename for f in comparison.files]
+        requester = self.repo._requester
 
-        return filenames
+        # Hack: We're extracting the authorization and user agent headers from the PyGithub library to get this diff
+        # This has to be done because the files list inside the comparison object is limited to only 300 files.
+        # We get the entire diff from the diff object returned from the `diff_url`
+        # Pinged this github issue in hopes that the library will implement it: https://github.com/PyGithub/PyGithub/issues/2027
+        headers = {
+            "Authorization": f"{requester._Requester__auth.token_type} {requester._Requester__auth.token}",  # type: ignore
+            "User-Agent": requester._Requester__userAgent,  # type: ignore
+        }
+        data = requests.get(comparison.diff_url, headers=headers).content
+
+        patch_set = PatchSet(data.decode("utf-8"))
+
+        added_files = [patch.path for patch in patch_set.added_files]
+        modified_files = [patch.path for patch in patch_set.modified_files]
+        removed_files = [patch.path for patch in patch_set.removed_files]
+
+        changed_files = list(set(added_files + modified_files))
+
+        return changed_files, removed_files
 
     def _get_data(self):
         documents, nodes = self._load_data_from_github()
@@ -229,23 +249,35 @@ class AgentContext:
         )
 
         # Update the documents that changed in the diff.
-        filenames = self._get_commit_file_diffs()
+        changed_files, deleted_files = self._get_commit_file_diffs()
 
-        logger.debug(f"Updating index with {len(filenames)} files")
+        logger.debug(
+            f"Updating index with {len(changed_files)} changed files and {len(deleted_files)} deleted files"
+        )
 
         self.index = index
         self.documents = documents
         self.nodes = nodes
 
         documents_to_update = [
-            document for document in documents if document.metadata["file_path"] in filenames
+            document for document in documents if document.metadata["file_path"] in changed_files
+        ]
+        documents_to_delete = [
+            document for document in documents if document.metadata["file_path"] in deleted_files
         ]
 
-        for document in documents_to_update:
+        for document in documents_to_update + documents_to_delete:
             self.index.delete(document.get_doc_id())
 
-        new_nodes = self._documents_to_nodes(documents_to_update)
-        self.index.insert_nodes(new_nodes)
+        with sentry_sdk.start_span(
+            op="seer.automation.autofix",
+            description="Run autofix on an issue within celery task",
+        ) as span:
+            new_nodes = self._documents_to_nodes(documents_to_update)
+            self.index.insert_nodes(new_nodes)
+
+            span.set_tag("num_documents", len(documents_to_update))
+            span.set_tag("num_nodes", len(new_nodes))
 
     def _get_document(self, file_path: str):
         for document in self.documents:

--- a/src/seer/automation/autofix/agent_context.py
+++ b/src/seer/automation/autofix/agent_context.py
@@ -270,8 +270,8 @@ class AgentContext:
             self.index.delete(document.get_doc_id())
 
         with sentry_sdk.start_span(
-            op="seer.automation.autofix",
-            description="Run autofix on an issue within celery task",
+            op="seer.automation.autofix.indexing",
+            description="Indexing the diff between the cached commit and the requested commit",
         ) as span:
             new_nodes = self._documents_to_nodes(documents_to_update)
             self.index.insert_nodes(new_nodes)


### PR DESCRIPTION
### Problem
Turns out the github compare API [returns a maximum of 300 files ](https://stackoverflow.com/a/71447308), breaking our code to embed the diff between the cached commit and the commit in the autofix request.

### Fix
Use the git diff API endpoint as the above stackoverflow post suggests which appears to return all file diffs (confirmed with a 1k file++ test run). We have to extract the git authorization headers from the PyGithub library and parse the diff locally. We also fix the issue with not correctly handling removed files.