### PR TITLE
chore: Add sentry sdk to celery worker

### DIFF
--- a/src/celery_app/app.py
+++ b/src/celery_app/app.py
@@ -1,7 +1,9 @@
 import logging
 import os
 
-from celery import Celery
+import sentry_sdk
+from celery import Celery, signals
+from sentry_sdk.integrations.celery import CeleryIntegration
 
 logger = logging.getLogger(__name__)
 
@@ -22,3 +24,15 @@ app.conf.task_queues = {
     },
 }
 app.autodiscover_tasks(["celery_app.tasks"])
+
+
+@signals.celeryd_init.connect
+def init_sentry(**_kwargs):
+    print("init_sentry DONE")
+    sentry_sdk.init(
+        dsn=os.environ.get("SENTRY_DSN"),
+        integrations=[CeleryIntegration(propagate_traces=True)],
+        traces_sample_rate=1.0,
+        profiles_sample_rate=1.0,
+        enable_tracing=True,
+    )

--- a/src/celery_app/app.py
+++ b/src/celery_app/app.py
@@ -28,7 +28,6 @@ app.autodiscover_tasks(["celery_app.tasks"])
 
 @signals.celeryd_init.connect
 def init_sentry(**_kwargs):
-    print("init_sentry DONE")
     sentry_sdk.init(
         dsn=os.environ.get("SENTRY_DSN"),
         integrations=[CeleryIntegration(propagate_traces=True)],


### PR DESCRIPTION
Weren't getting any sentry errors even though there were errors within the worker. Uses same DSN as the normal seer.