### PR TITLE
fix(rpc): Only return json rpc response when it actually is a json

### DIFF
--- a/src/seer/rpc.py
+++ b/src/seer/rpc.py
@@ -36,4 +36,8 @@ class RPCClient:
         }
         response = requests.post(endpoint, headers=headers, json=body_dict)
         response.raise_for_status()
-        return response.json()
+
+        if response.headers.get("Content-Type") == "application/json":
+            return response.json()
+        else:
+            return None


### PR DESCRIPTION
Response could just be None from the rpc endpoint thus it was throwing an error in gcp logs