### PR TITLE
fix(autofix): Acquire file locks when embedding repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,6 @@ COPY pyproject.toml .
 COPY supervisord.conf /etc/supervisord.conf
 
 RUN pip install --default-timeout=120 -e .
-# RUN mypy
+RUN mypy
 
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisord.conf"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,6 @@ COPY pyproject.toml .
 COPY supervisord.conf /etc/supervisord.conf
 
 RUN pip install --default-timeout=120 -e .
-RUN mypy
+# RUN mypy
 
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisord.conf"]

--- a/celeryworker.sh
+++ b/celeryworker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "$CELERY_WORKER_ENABLE" = "true" ]; then
-    exec celery -A src.celery_app.tasks worker --loglevel=debug
+    exec celery -A src.celery_app.tasks worker --loglevel=debug -c 4 # 4 workers for now because we don't acquire locks on the embedding files
 else
     echo "Celery worker is disabled via environment variable CELERY_WORKER_ENABLE"
     exit 0

--- a/celeryworker.sh
+++ b/celeryworker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "$CELERY_WORKER_ENABLE" = "true" ]; then
-    exec celery -A src.celery_app.tasks worker --loglevel=debug -c 4 # 4 workers for now because we don't acquire locks on the embedding files
+    exec celery -A src.celery_app.tasks worker --loglevel=info -c 4 # 4 workers for now
 else
     echo "Celery worker is disabled via environment variable CELERY_WORKER_ENABLE"
     exit 0

--- a/src/celery_app/app.py
+++ b/src/celery_app/app.py
@@ -11,6 +11,9 @@ broker_url = os.environ.get("CELERY_BROKER_URL")
 if not broker_url:
     logger.warning("CELERY_BROKER_URL not set")
 
+autofix_logger = logging.getLogger("autofix")
+autofix_logger.setLevel(logging.DEBUG)  # log level debug only for the autofix logger
+
 app = Celery("seer", broker=broker_url)
 app.conf.task_serializer = "json"
 app.conf.result_serializer = "json"

--- a/src/seer/automation/autofix/agent_context.py
+++ b/src/seer/automation/autofix/agent_context.py
@@ -5,7 +5,6 @@ import os
 import shutil
 import tarfile
 import tempfile
-from random import randint
 from typing import List
 
 import requests
@@ -80,10 +79,7 @@ class AgentContext:
             self.base_sha = self.repo.get_git_ref(ref).object.sha
 
         if tmp_dir is None:
-            tmp_dir = os.path.join(
-                tempfile.gettempdir(),
-                f"{repo_owner}-{repo_name}_{self.base_sha}_{randint(0, 100000)}",
-            )
+            tmp_dir = tempfile.mkdtemp(prefix=f"{repo_owner}-{repo_name}_{self.base_sha}")
         self.tmp_dir = tmp_dir
         self.tmp_repo_path = os.path.join(self.tmp_dir, f"repo")
         self.cached_commit_json_path = os.path.join("./", "models/autofix_cached_commit.json")

--- a/src/seer/automation/autofix/agent_context.py
+++ b/src/seer/automation/autofix/agent_context.py
@@ -229,9 +229,8 @@ class AgentContext:
         return changed_files, removed_files
 
     def _get_data(self):
-        # Because we acquire separate read and write locks with the embedding step in between; there is a chance that
-        # we may be embedding the same diff twice. But this should be a rare case and otherwise we would be blocking multiple
-        # requests from running in parallel if we acquire a lock for the entire process of reading and writing the index.
+        # The files will be locked for the entire process of loading data; that means only one worker at a time can go through the data loading process which is a bottleneck.
+        # However, this should be a temporary compromise during PoC stage to ensure that only the latest commit's embeddings are stored.
         try:
             documents, nodes = self._load_data_from_github()
 

--- a/src/seer/automation/autofix/autofix.py
+++ b/src/seer/automation/autofix/autofix.py
@@ -20,8 +20,6 @@ from seer.automation.autofix.types import (
 REPO_OWNER = "getsentry"
 
 logger = logging.getLogger("autofix")
-logger.addHandler(logging.FileHandler("./autofix.log"))
-logger.addHandler(logging.StreamHandler())
 
 
 class Autofix:


### PR DESCRIPTION
## Problems
1. Turns out the celery process runs as many workers as the number of available CPU cores. This means there will be concurrent processes.
2. The embedding files are not locked
3. We aren't also correctly removing the temp directory if the pipeline short circuited or errored.
4. We were logging debug logs from various libraries as well because of the blanket log level debug setting

## Fixes
1. Set max concurrency on the celery process to 4 workers
2. Lock the embedding files throughout the whole data loading process.
    - The files will be locked for the entire process of loading data; that means only one worker at a time can go through the data loading process which is a bottleneck. However, this should be a temporary compromise during PoC stage to ensure that only the latest commit's embeddings are stored.
3. Remove the temp dir at the end of the data loading step
5. Remove debug log level on the celery process as that was enabling debug logs for libraries as well; instead we just need debug logging on the autofix logger.