### PR TITLE
fix(autofix): Support reverse git diffs

### DIFF
--- a/src/seer/automation/autofix/utils.py
+++ b/src/seer/automation/autofix/utils.py
@@ -188,7 +188,7 @@ class SentenceTransformersEmbedding(BaseEmbedding):
                 device = torch.device("mps")
             else:
                 device = torch.device("cpu")
-        print("device", device)
+
         self._model = SentenceTransformer(model_name).to(device)
 
         super().__init__()


### PR DESCRIPTION
If the second commit in a git diff is in the past it returns an empty diff; the functionality we need is essentially to be able to turn the repo from one state to another. To accomplish this we implement an arbitrary "reverse diff" where the added files are now removed files, and the modified/deleted files become the changed files.

This PR also includes improvements to logging.

Tested locally