### PR TITLE
feat(ai-autofix): Short circuit the diff embedding step with stacktrace files

### DIFF
--- a/src/celery_app/tasks.py
+++ b/src/celery_app/tasks.py
@@ -17,7 +17,7 @@ class TaskStatusRequest(BaseModel):
     task_id: str
 
 
-@celery_app.task(time_limit=60 * 20)  # 20 minutes
+@celery_app.task(time_limit=60 * 60)  # 1 hour task timeout
 def run_autofix(data: dict[str, Any]) -> None:
     base_url = os.environ.get("SENTRY_BASE_URL")
     if not base_url:

--- a/src/celery_app/tasks.py
+++ b/src/celery_app/tasks.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 
 from celery_app.app import app as celery_app
 from seer.automation.autofix.autofix import Autofix
-from seer.automation.autofix.types import AutofixRequest
+from seer.automation.autofix.models import AutofixRequest
 from seer.rpc import SentryRpcClient
 
 logger = logging.getLogger("autofix")

--- a/src/seer/app.py
+++ b/src/seer/app.py
@@ -8,7 +8,7 @@ from flask import Flask
 from sentry_sdk.integrations.flask import FlaskIntegration
 
 from celery_app.tasks import run_autofix
-from seer.automation.autofix.types import AutofixEndpointResponse, AutofixRequest
+from seer.automation.autofix.models import AutofixEndpointResponse, AutofixRequest
 from seer.grouping.grouping import GroupingLookup, GroupingRequest, SimilarityResponse
 from seer.json_api import json_api, register_json_api_views
 from seer.severity.severity_inference import SeverityInference, SeverityRequest, SeverityResponse

--- a/src/seer/automation/autofix/autofix.py
+++ b/src/seer/automation/autofix/autofix.py
@@ -56,7 +56,8 @@ class Autofix:
         try:
             logger.info(f"Beginning autofix for issue {self.request.issue.id}")
 
-            stacktrace = self.request.issue.events[-1].get_stacktrace()
+            events = self.request.issue.events
+            stacktrace = events[-1].get_stacktrace() if events else None
             if not stacktrace:
                 logger.warning(f"No stacktrace found for issue {self.request.issue.id}")
 

--- a/src/seer/automation/autofix/autofix.py
+++ b/src/seer/automation/autofix/autofix.py
@@ -90,16 +90,17 @@ class Autofix:
             try:
                 self.autofix_context.load_codebase()
 
+                if not self.autofix_context.codebase_context:
+                    logger.warning(f"Failed to load codebase context")
+                    self.event_manager.send_codebase_indexing_result("ERROR")
+                    return
+
                 # Below is the short circuit logic to skip embedding the codebase context if the stacktrace
                 # does not contain any files that need to be re-indexed
                 needs_indexing = self.autofix_context.diff_contains_stacktrace_files(
                     self.stacktrace
                 )
                 if needs_indexing:
-                    assert (
-                        self.autofix_context.codebase_context is not None
-                    ), "Codebase context is not loaded"
-
                     logger.debug(f"Updating codebase index")
                     self.autofix_context.codebase_context.update_codebase_index()
                 else:

--- a/src/seer/automation/autofix/autofix_context.py
+++ b/src/seer/automation/autofix/autofix_context.py
@@ -1,3 +1,5 @@
+import tempfile
+
 from seer.automation.autofix.codebase_context import CodebaseContext
 from seer.automation.autofix.models import Stacktrace
 from seer.automation.autofix.repo_client import RepoClient
@@ -12,7 +14,11 @@ class AutofixContext:
         self.base_sha = base_sha
 
     def load_codebase(self):
-        self.codebase_context = CodebaseContext(self.repo_client, self.base_sha)
+        tmp_dir = tempfile.mkdtemp(
+            prefix=f"{self.repo_client.repo_owner}-{self.repo_client.repo_name}_{self.base_sha}"
+        )
+
+        self.codebase_context = CodebaseContext(self.repo_client, self.base_sha, tmp_dir)
 
     def diff_contains_stacktrace_files(self, stacktrace: Stacktrace) -> bool:
         cached_sha = CodebaseContext.get_cached_commit_sha()

--- a/src/seer/automation/autofix/autofix_context.py
+++ b/src/seer/automation/autofix/autofix_context.py
@@ -3,7 +3,7 @@ from seer.automation.autofix.models import Stacktrace
 from seer.automation.autofix.repo_client import RepoClient
 
 
-class ContextManager:
+class AutofixContext:
     codebase_context: CodebaseContext | None = None
     repo_client: RepoClient
 

--- a/src/seer/automation/autofix/codebase_context.py
+++ b/src/seer/automation/autofix/codebase_context.py
@@ -3,7 +3,6 @@ import logging
 import os
 import shutil
 import tarfile
-import tempfile
 from typing import List
 
 import requests
@@ -44,13 +43,11 @@ class CodebaseContext:
     documents: list[Document]
     nodes: list[BaseNode]
 
-    def __init__(self, repo_client: RepoClient, base_sha: str):
+    def __init__(self, repo_client: RepoClient, base_sha: str, tmp_dir: str):
         self.repo_client = repo_client
         self.base_sha = base_sha
 
-        self.tmp_dir = tempfile.mkdtemp(
-            prefix=f"{repo_client.repo_owner}-{repo_client.repo_name}_{self.base_sha}"
-        )
+        self.tmp_dir = tmp_dir
         self.tmp_repo_path = os.path.join(self.tmp_dir, f"repo")
 
         logger.info(f"Using tmp dir {self.tmp_dir}")

--- a/src/seer/automation/autofix/codebase_context.py
+++ b/src/seer/automation/autofix/codebase_context.py
@@ -63,17 +63,22 @@ class CodebaseContext:
 
     @staticmethod
     def get_cached_commit_sha() -> str | None:
-        cached_commit_sha = None
-        with open(CACHED_COMMIT_JSON_PATH, "r") as file:
-            cached_commit_data = json.load(file)
-            cached_commit_sha = cached_commit_data.get("sha")
-
-        return cached_commit_sha
+        try:
+            with open(CACHED_COMMIT_JSON_PATH, "r") as file:
+                cached_commit_data = json.load(file)
+                cached_commit_sha = cached_commit_data.get("sha")
+                return cached_commit_sha
+        except IOError:
+            logger.error(f"Failed to read cached commit file: {CACHED_COMMIT_JSON_PATH}")
+            return None
 
     @staticmethod
     def set_cached_commit_sha(sha: str):
-        with open(CACHED_COMMIT_JSON_PATH, "w") as sha_file:
-            json.dump({"sha": sha}, sha_file)
+        try:
+            with open(CACHED_COMMIT_JSON_PATH, "w") as sha_file:
+                json.dump({"sha": sha}, sha_file)
+        except IOError:
+            logger.error(f"Failed to write cached commit file: {CACHED_COMMIT_JSON_PATH}")
 
     def _embed_and_index_nodes(self, nodes: list[BaseNode]) -> VectorStoreIndex:
         service_context = ServiceContext.from_defaults(embed_model=self.embed_model)

--- a/src/seer/automation/autofix/codebase_context.py
+++ b/src/seer/automation/autofix/codebase_context.py
@@ -8,10 +8,7 @@ from typing import List
 
 import requests
 import sentry_sdk
-import torch
-from filelock import SoftFileLock
-from github import Auth, Github, GithubIntegration
-from github.Repository import Repository
+from filelock import SoftFileLock, Timeout
 from llama_index import ServiceContext
 from llama_index.data_structs.data_structs import IndexDict
 from llama_index.indices import VectorStoreIndex
@@ -19,10 +16,8 @@ from llama_index.node_parser import CodeSplitter
 from llama_index.readers import SimpleDirectoryReader
 from llama_index.schema import BaseNode, Document
 from llama_index.storage import StorageContext
-from unidiff import PatchSet
 
-from seer.automation.agent.types import Usage
-from seer.automation.autofix.repo_client import get_github_auth
+from seer.automation.autofix.repo_client import RepoClient
 from seer.automation.autofix.utils import (
     MemoryVectorStore,
     SentenceTransformersEmbedding,
@@ -31,11 +26,13 @@ from seer.automation.autofix.utils import (
 
 logger = logging.getLogger("autofix")
 
+CACHED_COMMIT_JSON_PATH = os.path.join("./", "models/autofix_cached_commit.json")
+STORAGE_DIR = os.path.join("./", "models/autofix_storage_context/")
+LOCK_PATH = os.path.join(STORAGE_DIR, "lock")
+
 
 class CodebaseContext:
-    github_auth: Auth.Token | Auth.AppInstallationAuth
-    github: Github
-    repo: Repository
+    repo_client: RepoClient
     base_sha: str
 
     tmp_dir: str
@@ -47,15 +44,14 @@ class CodebaseContext:
     documents: list[Document]
     nodes: list[BaseNode]
 
-    def __init__(self, repo_owner: str, repo_name: str, base_sha: str):
-        self.github = Github(auth=get_github_auth(repo_owner, repo_name))
-        self.repo = self.github.get_repo(repo_owner + "/" + repo_name)
-
+    def __init__(self, repo_client: RepoClient, base_sha: str):
+        self.repo_client = repo_client
         self.base_sha = base_sha
 
-        self.tmp_dir = tempfile.mkdtemp(prefix=f"{repo_owner}-{repo_name}_{self.base_sha}")
+        self.tmp_dir = tempfile.mkdtemp(
+            prefix=f"{repo_client.repo_owner}-{repo_client.repo_name}_{self.base_sha}"
+        )
         self.tmp_repo_path = os.path.join(self.tmp_dir, f"repo")
-        self.cached_commit_json_path = os.path.join("./", "models/autofix_cached_commit.json")
 
         logger.info(f"Using tmp dir {self.tmp_dir}")
 
@@ -64,6 +60,20 @@ class CodebaseContext:
         )
 
         self._get_data()
+
+    @staticmethod
+    def get_cached_commit_sha() -> str | None:
+        cached_commit_sha = None
+        with open(CACHED_COMMIT_JSON_PATH, "r") as file:
+            cached_commit_data = json.load(file)
+            cached_commit_sha = cached_commit_data.get("sha")
+
+        return cached_commit_sha
+
+    @staticmethod
+    def set_cached_commit_sha(sha: str):
+        with open(CACHED_COMMIT_JSON_PATH, "w") as sha_file:
+            json.dump({"sha": sha}, sha_file)
 
     def _embed_and_index_nodes(self, nodes: list[BaseNode]) -> VectorStoreIndex:
         service_context = ServiceContext.from_defaults(embed_model=self.embed_model)
@@ -122,7 +132,7 @@ class CodebaseContext:
             for name in dirs:
                 os.rmdir(os.path.join(root, name))
 
-        tarball_url = self.repo.get_archive_link("tarball", ref=self.base_sha)
+        tarball_url = self.repo_client.repo.get_archive_link("tarball", ref=self.base_sha)
 
         response = requests.get(tarball_url, stream=True)
         if response.status_code == 200:
@@ -170,7 +180,9 @@ class CodebaseContext:
             logger.error(f"Failed to delete tar file: {e}")
 
     def _load_data_from_github(self):
-        logger.debug(f"Loading data from github for {self.repo.name} on ref {self.base_sha}")
+        logger.debug(
+            f"Loading data from github for {self.repo_client.repo.full_name} on ref {self.base_sha}"
+        )
         self._load_repo_to_tmp_dir()
         documents = SimpleDirectoryReader(
             self.tmp_repo_path, required_exts=[".py"], recursive=True
@@ -178,42 +190,6 @@ class CodebaseContext:
         nodes = self._documents_to_nodes(documents)
 
         return documents, nodes
-
-    def _get_commit_file_diffs(self, prev_sha: str) -> tuple[list[str], list[str]]:
-        """
-        Returns the list of files to change and files to delete in the diff in order to turn a commit into another.
-        """
-        comparison = self.repo.compare(prev_sha, self.base_sha)
-
-        # Support reverse diffs, because the api would return an empty list of files if the comparison is behind
-        is_behind = comparison.status == "behind"
-        if is_behind:
-            comparison = self.repo.compare(self.base_sha, prev_sha)
-
-        # Hack: We're extracting the authorization and user agent headers from the PyGithub library to get this diff
-        # This has to be done because the files list inside the comparison object is limited to only 300 files.
-        # We get the entire diff from the diff object returned from the `diff_url`
-        requester = self.repo._requester
-        headers = {
-            "Authorization": f"{requester._Requester__auth.token_type} {requester._Requester__auth.token}",  # type: ignore
-            "User-Agent": requester._Requester__userAgent,  # type: ignore
-        }
-        data = requests.get(comparison.diff_url, headers=headers).content
-
-        patch_set = PatchSet(data.decode("utf-8"))
-
-        added_files = [patch.path for patch in patch_set.added_files]
-        modified_files = [patch.path for patch in patch_set.modified_files]
-        removed_files = [patch.path for patch in patch_set.removed_files]
-
-        if is_behind:
-            # If the comparison is behind, the added files are actually the removed files
-            changed_files = list(set(modified_files + removed_files))
-            removed_files = added_files
-        else:
-            changed_files = list(set(added_files + modified_files))
-
-        return changed_files, removed_files
 
     def _get_data(self):
         # The files will be locked for the entire process of loading data; that means only one worker at a time can go through the data loading process which is a bottleneck.
@@ -223,24 +199,23 @@ class CodebaseContext:
 
             logger.debug(f"Loading index from storage context")
 
-            storage_dir = os.path.join("./", "models/autofix_storage_context/")
-            lock_path = os.path.join(storage_dir, "lock")
-
-            with SoftFileLock(os.path.join(lock_path), timeout=60 * 60):  # 1 hour max lock timeout
-                logger.debug(f"Acquired lock for {storage_dir}")
+            with SoftFileLock(
+                os.path.join(LOCK_PATH), timeout=60 * 60
+            ):  # 1 hour max read lock timeout
+                logger.debug(f"Acquired lock for {STORAGE_DIR}")
                 with sentry_sdk.start_span(
                     op="seer.automation.autofix.index_loading",
                     description="Loading the vector store index from local filesystem",
                 ) as span:
-                    with open(self.cached_commit_json_path, "r") as file:
-                        cached_commit_data = json.load(file)
-                    cached_commit_sha = cached_commit_data.get("sha")
+                    cached_commit_sha = self.get_cached_commit_sha()
+
+                    assert cached_commit_sha is not None, "Cached commit SHA not found"
 
                     service_context = ServiceContext.from_defaults(embed_model=self.embed_model)
-                    memory_vector_store = MemoryVectorStore().from_persist_dir(storage_dir)
+                    memory_vector_store = MemoryVectorStore().from_persist_dir(STORAGE_DIR)
                     storage_context = StorageContext.from_defaults(
                         vector_store=memory_vector_store,
-                        persist_dir=storage_dir,
+                        persist_dir=STORAGE_DIR,
                     )
                     index_structs = storage_context.index_store.index_structs()
 
@@ -255,66 +230,84 @@ class CodebaseContext:
                         show_progress=False,
                     )
 
-                logger.debug(f"Loaded index from storage context '{storage_dir}'.")
-
-                # Update the documents that changed in the diff.
-                changed_files, deleted_files = self._get_commit_file_diffs(cached_commit_sha)
-
-                logger.debug(
-                    f"Updating index with {len(changed_files)} changed files and {len(deleted_files)} deleted files"
-                )
-
                 self.index = index
                 self.documents = documents
                 self.nodes = nodes
 
-                documents_to_update = [
-                    document
-                    for document in documents
-                    if document.metadata["file_path"] in changed_files
-                ]
-                documents_to_delete = [
-                    document
-                    for document in documents
-                    if document.metadata["file_path"] in deleted_files
-                ]
+                logger.debug(f"Loaded index from storage context '{STORAGE_DIR}'.")
 
-                for document in documents_to_update + documents_to_delete:
-                    self.index.delete(document.get_doc_id())
-
-                with sentry_sdk.start_span(
-                    op="seer.automation.autofix.indexing",
-                    description="Indexing the diff between the cached commit and the requested commit",
-                ) as span:
-                    logger.debug(f"Begin index update...")
-                    new_nodes = self._documents_to_nodes(documents_to_update)
-                    self.index.insert_nodes(new_nodes)
-
-                    span.set_tag("num_documents", len(documents_to_update))
-                    span.set_tag("num_nodes", len(new_nodes))
-
-                commit_is_newer = self.repo.compare(cached_commit_sha, self.base_sha).ahead_by > 0
-
-                if commit_is_newer:
-                    # Save only when the commit is newer
-                    storage_context.persist(persist_dir=storage_dir)
-                    memory_vector_store.persist(
-                        persist_path=os.path.join(storage_dir, "vector_store.json")
-                    )
-
-                    try:
-                        os.remove(os.path.join(storage_dir, "default__vector_store.json"))
-                    except OSError as e:
-                        logger.error(f"Failed to delete default vector store file: {e}")
-
-                    with open(self.cached_commit_json_path, "w") as sha_file:
-                        json.dump({"sha": self.base_sha}, sha_file)
-
-                logger.debug(f"Released lock for {storage_dir}")
+            logger.debug(f"Released lock for {STORAGE_DIR}")
 
         finally:
             # Always cleanup the tmp dir
             self.cleanup()
+
+    def update_codebase_index(self):
+        cached_commit_sha = self.get_cached_commit_sha()
+
+        assert cached_commit_sha is not None, "Cached commit SHA not found"
+
+        changed_files, deleted_files = self.repo_client.get_commit_file_diffs(
+            cached_commit_sha, self.base_sha
+        )
+
+        logger.debug(
+            f"Updating index with {len(changed_files)} changed files and {len(deleted_files)} deleted files"
+        )
+
+        documents_to_update = [
+            document
+            for document in self.documents
+            if document.metadata["file_path"] in changed_files
+        ]
+        documents_to_delete = [
+            document
+            for document in self.documents
+            if document.metadata["file_path"] in deleted_files
+        ]
+
+        for document in documents_to_update + documents_to_delete:
+            self.index.delete(document.get_doc_id())
+
+        with sentry_sdk.start_span(
+            op="seer.automation.autofix.indexing",
+            description="Indexing the diff between the cached commit and the requested commit",
+        ) as span:
+            logger.debug(f"Begin index update...")
+            new_nodes = self._documents_to_nodes(documents_to_update)
+            self.index.insert_nodes(new_nodes)
+
+            span.set_tag("num_documents", len(documents_to_update))
+            span.set_tag("num_nodes", len(new_nodes))
+
+        commit_is_newer = (
+            self.repo_client.repo.compare(cached_commit_sha, self.base_sha).ahead_by > 0
+        )
+
+        if commit_is_newer:
+            # Save only when the commit is newer
+            logger.debug(f"Saving index to storage context")
+            try:
+                with SoftFileLock(
+                    os.path.join(LOCK_PATH), timeout=60 * 15
+                ):  # 15 minute max write lock timeout
+                    logger.debug(f"Acquired lock for {STORAGE_DIR}")
+                    self.index.storage_context.persist(persist_dir=STORAGE_DIR)
+                    self.index.vector_store.persist(
+                        persist_path=os.path.join(STORAGE_DIR, "vector_store.json")
+                    )
+
+                    try:
+                        os.remove(os.path.join(STORAGE_DIR, "default__vector_store.json"))
+                    except OSError as e:
+                        logger.error(f"Failed to delete default vector store file: {e}")
+
+                    self.set_cached_commit_sha(self.base_sha)
+                logger.debug(f"Released lock for {STORAGE_DIR}")
+            except Timeout:
+                logger.warning(
+                    f"Timed out waiting for lock to save {STORAGE_DIR}, skipping save..."
+                )
 
     def _get_document(self, file_path: str):
         for document in self.documents:
@@ -354,9 +347,11 @@ class CodebaseContext:
                 self.nodes.extend(new_nodes)
 
     def get_file_contents(self, path, ref):
-        logger.debug(f"Getting file contents for {path} in {self.repo.name} on ref {ref}")
+        logger.debug(
+            f"Getting file contents for {path} in {self.repo_client.repo.full_name} on ref {ref}"
+        )
         try:
-            contents = self.repo.get_contents(path, ref=ref)
+            contents = self.repo_client.repo.get_contents(path, ref=ref)
 
             if isinstance(contents, list):
                 raise Exception(f"Expected a single ContentFile but got a list for path {path}")
@@ -365,7 +360,7 @@ class CodebaseContext:
         except Exception as e:
             logger.error(f"Error getting file contents: {e}")
 
-            return f"Error: file with path {path} not found in {self.repo.name} on ref {ref}"
+            return f"Error: file with path {path} not found in {self.repo_client.repo.full_name} on ref {ref}"
 
     def cleanup(self):
         if os.path.exists(self.tmp_dir):

--- a/src/seer/automation/autofix/context_manager.py
+++ b/src/seer/automation/autofix/context_manager.py
@@ -1,0 +1,29 @@
+from seer.automation.autofix.codebase_context import CodebaseContext
+from seer.automation.autofix.models import Stacktrace
+from seer.automation.autofix.repo_client import RepoClient
+
+
+class ContextManager:
+    codebase_context: CodebaseContext | None = None
+    repo_client: RepoClient
+
+    def __init__(self, repo_client: RepoClient, base_sha: str):
+        self.repo_client = repo_client
+        self.base_sha = base_sha
+
+    def load_codebase(self):
+        self.codebase_context = CodebaseContext(self.repo_client, self.base_sha)
+
+    def diff_contains_stacktrace_files(self, stacktrace: Stacktrace) -> bool:
+        cached_sha = CodebaseContext.get_cached_commit_sha()
+        if cached_sha is None:
+            raise FileNotFoundError("Cached commit SHA not found")
+
+        changed_files, removed_files = self.repo_client.get_commit_file_diffs(
+            cached_sha, self.base_sha
+        )
+
+        change_files = set(changed_files + removed_files)
+        stacktrace_files = set([frame.filename for frame in stacktrace.frames])
+
+        return bool(change_files.intersection(stacktrace_files))

--- a/src/seer/automation/autofix/event_manager.py
+++ b/src/seer/automation/autofix/event_manager.py
@@ -3,7 +3,7 @@ from typing import Literal, Optional
 
 from pydantic import BaseModel
 
-from seer.automation.autofix.types import AutofixOutput, PlanningOutput, ProblemDiscoveryResult
+from seer.automation.autofix.models import AutofixOutput, PlanningOutput, ProblemDiscoveryResult
 from seer.rpc import RpcClient
 
 Status = Literal["COMPLETED", "ERROR", "PENDING", "PROCESSING", "CANCELLED"]
@@ -34,6 +34,19 @@ class AutofixEventManager:
             status=status,
             steps=[step.model_dump() for step in self.steps],
         )
+
+    def send_no_stacktrace_error(self):
+        self.steps = [
+            Step(
+                id="problem_discovery",
+                index=0,
+                title="Preliminary Assessment",
+                status="ERROR",
+                description="Error: Cannot fix issues without a stacktrace.",
+            )
+        ]
+
+        self._send_steps_update("ERROR")
 
     def send_initial_steps(self):
         self.steps = [

--- a/src/seer/automation/autofix/prompts.py
+++ b/src/seer/automation/autofix/prompts.py
@@ -1,7 +1,7 @@
 import textwrap
 from typing import Optional
 
-from seer.automation.autofix.types import PlanStep, ProblemDiscoveryOutput
+from seer.automation.autofix.models import PlanStep, ProblemDiscoveryOutput
 
 
 def format_additional_context(additional_context: str):

--- a/src/seer/automation/autofix/tools.py
+++ b/src/seer/automation/autofix/tools.py
@@ -7,7 +7,7 @@ from llama_index.schema import MetadataMode
 
 from seer.automation.agent.tools import FunctionTool
 from seer.automation.autofix.codebase_context import CodebaseContext
-from seer.automation.autofix.types import FileChange
+from seer.automation.autofix.models import FileChange
 from seer.automation.autofix.utils import find_original_snippet
 
 logger = logging.getLogger("autofix")
@@ -96,30 +96,27 @@ class BaseTools:
 
 
 class CodeActionTools(BaseTools):
-    context: CodebaseContext
-    base_sha: str
+    codebase_context: CodebaseContext
     file_changes: list[FileChange]
 
     _snippet_matching_threshold = 0.9
 
     def __init__(
         self,
-        context: CodebaseContext,
-        base_sha: str,
+        codebase_context: CodebaseContext,
         verbose: bool = False,
     ):
-        super().__init__(context)
+        super().__init__(codebase_context)
 
-        self.context = context
-        self.base_sha = base_sha
+        self.codebase_context = codebase_context
         self.verbose = verbose
         self.file_changes = []
 
     def _get_latest_file_contents(self, file_path: str):
         logger.debug(
-            f"Getting file contents from Github for file_path: {file_path} from sha {self.base_sha}"
+            f"Getting file contents from Github for file_path: {file_path} from sha {self.codebase_context}"
         )
-        contents = self.context.get_file_contents(file_path, self.base_sha)
+        contents = self.context.get_file_contents(file_path, self.codebase_context)
 
         changes = list(filter(lambda x: x.path == file_path, self.file_changes))
         if changes:

--- a/src/seer/automation/autofix/utils.py
+++ b/src/seer/automation/autofix/utils.py
@@ -14,8 +14,6 @@ from llama_index.embeddings.base import BaseEmbedding
 from llama_index.vector_stores import SimpleVectorStore
 from sentence_transformers import SentenceTransformer
 
-from seer.automation.autofix.types import ProblemDiscoveryOutput
-
 logger = logging.getLogger("autofix")
 
 VALID_BRANCH_NAME_CHARS = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-"

--- a/tests/automation/autofix/test_autofix.py
+++ b/tests/automation/autofix/test_autofix.py
@@ -1,0 +1,234 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from seer.automation.autofix.autofix import Autofix
+from seer.automation.autofix.models import (
+    AutofixRequest,
+    IssueDetails,
+    PlanningOutput,
+    ProblemDiscoveryOutput,
+    ProblemDiscoveryResult,
+    SentryEvent,
+)
+
+
+class TestAutoFixRunFlow(unittest.TestCase):
+    @patch("seer.automation.autofix.autofix.AutofixEventManager")
+    @patch("seer.automation.autofix.autofix.RepoClient")
+    @patch("seer.automation.autofix.autofix.ContextManager")
+    def test_problem_discovery_short_circuit(
+        self,
+        mock_context_manager,
+        mock_repo_client,
+        mock_event_manager,
+    ):
+        autofix = Autofix(
+            request=AutofixRequest(
+                additional_context="",
+                base_commit_sha="",
+                issue=IssueDetails(
+                    id=1,
+                    title="",
+                    events=[
+                        SentryEvent(
+                            entries=[
+                                {
+                                    "type": "exception",
+                                    "data": {
+                                        "values": [
+                                            {
+                                                "stacktrace": {
+                                                    "frames": [
+                                                        {
+                                                            "function": "test",
+                                                            "filename": "file2.py",
+                                                            "lineNo": 10,
+                                                            "colNo": 0,
+                                                            "context": [],
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    },
+                                }
+                            ]
+                        )
+                    ],
+                ),
+            ),
+            rpc_client=MagicMock(),
+        )
+
+        autofix.run_problem_discovery_agent = MagicMock()
+        autofix.run_problem_discovery_agent.return_value = ProblemDiscoveryOutput(
+            actionability_score=0.5,
+            description="",
+            reasoning="",
+        )
+
+        autofix.run()
+
+        autofix.run_problem_discovery_agent.assert_called_once()
+        autofix.event_manager.send_problem_discovery_result.assert_called_once_with(
+            ProblemDiscoveryResult(
+                status="CANCELLED",
+                description="",
+                reasoning="",
+            )
+        )
+        autofix.context_manager.load_codebase.assert_not_called()
+
+    @patch("seer.automation.autofix.autofix.AutofixEventManager")
+    @patch("seer.automation.autofix.autofix.RepoClient")
+    @patch("seer.automation.autofix.autofix.ContextManager")
+    def test_stacktrace_files_short_circuit(
+        self,
+        mock_context_manager,
+        mock_repo_client,
+        mock_event_manager,
+    ):
+        autofix = Autofix(
+            request=AutofixRequest(
+                additional_context="",
+                base_commit_sha="",
+                issue=IssueDetails(
+                    id=1,
+                    title="",
+                    events=[
+                        SentryEvent(
+                            entries=[
+                                {
+                                    "type": "exception",
+                                    "data": {
+                                        "values": [
+                                            {
+                                                "stacktrace": {
+                                                    "frames": [
+                                                        {
+                                                            "function": "test",
+                                                            "filename": "file2.py",
+                                                            "lineNo": 10,
+                                                            "colNo": 0,
+                                                            "context": [],
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    },
+                                }
+                            ]
+                        )
+                    ],
+                ),
+            ),
+            rpc_client=MagicMock(),
+        )
+
+        autofix.context_manager.diff_contains_stacktrace_files = MagicMock()
+        autofix.context_manager.diff_contains_stacktrace_files.return_value = False
+        autofix.run_problem_discovery_agent = MagicMock()
+        autofix.run_problem_discovery_agent.return_value = ProblemDiscoveryOutput(
+            actionability_score=1.0,
+            description="",
+            reasoning="",
+        )
+        autofix.run_planning_agent = MagicMock()
+        autofix.run_planning_agent.return_value = PlanningOutput(title="", description="", steps=[])
+        autofix.run_execution_agent = MagicMock()
+
+        autofix.run()
+
+        autofix.run_problem_discovery_agent.assert_called_once()
+        autofix.event_manager.send_problem_discovery_result.assert_called_once_with(
+            ProblemDiscoveryResult(
+                status="CONTINUE",
+                description="",
+                reasoning="",
+            )
+        )
+        autofix.context_manager.load_codebase.assert_called_once()
+
+        assert autofix.context_manager.codebase_context is not None
+        autofix.context_manager.codebase_context.update_codebase_index.assert_not_called()
+
+        autofix.run_planning_agent.assert_called_once()
+        autofix.run_execution_agent.assert_not_called()
+
+    @patch("seer.automation.autofix.autofix.AutofixEventManager")
+    @patch("seer.automation.autofix.autofix.RepoClient")
+    @patch("seer.automation.autofix.autofix.ContextManager")
+    def test_stacktrace_not_short_circuit(
+        self,
+        mock_context_manager,
+        mock_repo_client,
+        mock_event_manager,
+    ):
+        autofix = Autofix(
+            request=AutofixRequest(
+                additional_context="",
+                base_commit_sha="",
+                issue=IssueDetails(
+                    id=1,
+                    title="",
+                    events=[
+                        SentryEvent(
+                            entries=[
+                                {
+                                    "type": "exception",
+                                    "data": {
+                                        "values": [
+                                            {
+                                                "stacktrace": {
+                                                    "frames": [
+                                                        {
+                                                            "function": "test",
+                                                            "filename": "file2.py",
+                                                            "lineNo": 10,
+                                                            "colNo": 0,
+                                                            "context": [],
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    },
+                                }
+                            ]
+                        )
+                    ],
+                ),
+            ),
+            rpc_client=MagicMock(),
+        )
+
+        autofix.context_manager.diff_contains_stacktrace_files = MagicMock()
+        autofix.context_manager.diff_contains_stacktrace_files.return_value = True
+        autofix.run_problem_discovery_agent = MagicMock()
+        autofix.run_problem_discovery_agent.return_value = ProblemDiscoveryOutput(
+            actionability_score=1.0,
+            description="",
+            reasoning="",
+        )
+        autofix.run_planning_agent = MagicMock()
+        autofix.run_planning_agent.return_value = PlanningOutput(title="", description="", steps=[])
+        autofix.run_execution_agent = MagicMock()
+
+        autofix.run()
+
+        autofix.run_problem_discovery_agent.assert_called_once()
+        autofix.event_manager.send_problem_discovery_result.assert_called_once_with(
+            ProblemDiscoveryResult(
+                status="CONTINUE",
+                description="",
+                reasoning="",
+            )
+        )
+        autofix.context_manager.load_codebase.assert_called_once()
+
+        assert autofix.context_manager.codebase_context is not None
+        autofix.context_manager.codebase_context.update_codebase_index.assert_called_once()
+
+        autofix.run_planning_agent.assert_called_once()
+        autofix.run_execution_agent.assert_not_called()

--- a/tests/automation/autofix/test_autofix.py
+++ b/tests/automation/autofix/test_autofix.py
@@ -15,7 +15,7 @@ from seer.automation.autofix.models import (
 class TestAutoFixRunFlow(unittest.TestCase):
     @patch("seer.automation.autofix.autofix.AutofixEventManager")
     @patch("seer.automation.autofix.autofix.RepoClient")
-    @patch("seer.automation.autofix.autofix.ContextManager")
+    @patch("seer.automation.autofix.autofix.AutofixContext")
     def test_problem_discovery_short_circuit(
         self,
         mock_context_manager,
@@ -77,11 +77,11 @@ class TestAutoFixRunFlow(unittest.TestCase):
                 reasoning="",
             )
         )
-        autofix.context_manager.load_codebase.assert_not_called()
+        autofix.autofix_context.load_codebase.assert_not_called()
 
     @patch("seer.automation.autofix.autofix.AutofixEventManager")
     @patch("seer.automation.autofix.autofix.RepoClient")
-    @patch("seer.automation.autofix.autofix.ContextManager")
+    @patch("seer.automation.autofix.autofix.AutofixContext")
     def test_stacktrace_files_short_circuit(
         self,
         mock_context_manager,
@@ -126,8 +126,8 @@ class TestAutoFixRunFlow(unittest.TestCase):
             rpc_client=MagicMock(),
         )
 
-        autofix.context_manager.diff_contains_stacktrace_files = MagicMock()
-        autofix.context_manager.diff_contains_stacktrace_files.return_value = False
+        autofix.autofix_context.diff_contains_stacktrace_files = MagicMock()
+        autofix.autofix_context.diff_contains_stacktrace_files.return_value = False
         autofix.run_problem_discovery_agent = MagicMock()
         autofix.run_problem_discovery_agent.return_value = ProblemDiscoveryOutput(
             actionability_score=1.0,
@@ -148,17 +148,17 @@ class TestAutoFixRunFlow(unittest.TestCase):
                 reasoning="",
             )
         )
-        autofix.context_manager.load_codebase.assert_called_once()
+        autofix.autofix_context.load_codebase.assert_called_once()
 
-        assert autofix.context_manager.codebase_context is not None
-        autofix.context_manager.codebase_context.update_codebase_index.assert_not_called()
+        assert autofix.autofix_context.codebase_context is not None
+        autofix.autofix_context.codebase_context.update_codebase_index.assert_not_called()
 
         autofix.run_planning_agent.assert_called_once()
         autofix.run_execution_agent.assert_not_called()
 
     @patch("seer.automation.autofix.autofix.AutofixEventManager")
     @patch("seer.automation.autofix.autofix.RepoClient")
-    @patch("seer.automation.autofix.autofix.ContextManager")
+    @patch("seer.automation.autofix.autofix.AutofixContext")
     def test_stacktrace_not_short_circuit(
         self,
         mock_context_manager,
@@ -203,8 +203,8 @@ class TestAutoFixRunFlow(unittest.TestCase):
             rpc_client=MagicMock(),
         )
 
-        autofix.context_manager.diff_contains_stacktrace_files = MagicMock()
-        autofix.context_manager.diff_contains_stacktrace_files.return_value = True
+        autofix.autofix_context.diff_contains_stacktrace_files = MagicMock()
+        autofix.autofix_context.diff_contains_stacktrace_files.return_value = True
         autofix.run_problem_discovery_agent = MagicMock()
         autofix.run_problem_discovery_agent.return_value = ProblemDiscoveryOutput(
             actionability_score=1.0,
@@ -225,10 +225,10 @@ class TestAutoFixRunFlow(unittest.TestCase):
                 reasoning="",
             )
         )
-        autofix.context_manager.load_codebase.assert_called_once()
+        autofix.autofix_context.load_codebase.assert_called_once()
 
-        assert autofix.context_manager.codebase_context is not None
-        autofix.context_manager.codebase_context.update_codebase_index.assert_called_once()
+        assert autofix.autofix_context.codebase_context is not None
+        autofix.autofix_context.codebase_context.update_codebase_index.assert_called_once()
 
         autofix.run_planning_agent.assert_called_once()
         autofix.run_execution_agent.assert_not_called()

--- a/tests/automation/autofix/test_context_manager.py
+++ b/tests/automation/autofix/test_context_manager.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import MagicMock
 
-from seer.automation.autofix.context_manager import ContextManager
+from seer.automation.autofix.autofix_context import AutofixContext
 from seer.automation.autofix.models import Stacktrace, StacktraceFrame
 
 
@@ -11,7 +11,7 @@ class TestContextManager(unittest.TestCase):
         self.repo_name = "automation"
         self.base_sha = "abc123"
         self.mock_repo_client = MagicMock()
-        self.context_manager = ContextManager(self.mock_repo_client, self.base_sha)
+        self.autofix_context = AutofixContext(self.mock_repo_client, self.base_sha)
 
     def test_diff_contains_stacktrace_files_with_intersection(self):
         # Mock the get_commit_file_diffs method to return changed and removed files
@@ -28,7 +28,7 @@ class TestContextManager(unittest.TestCase):
             ]
         )
         # Check if the diff contains stacktrace files
-        self.assertTrue(self.context_manager.diff_contains_stacktrace_files(stacktrace))
+        self.assertTrue(self.autofix_context.diff_contains_stacktrace_files(stacktrace))
 
     def test_diff_contains_stacktrace_files_without_intersection(self):
         # Mock the get_commit_file_diffs method to return changed and removed files
@@ -45,7 +45,7 @@ class TestContextManager(unittest.TestCase):
             ]
         )
         # Check if the diff contains stacktrace files
-        self.assertFalse(self.context_manager.diff_contains_stacktrace_files(stacktrace))
+        self.assertFalse(self.autofix_context.diff_contains_stacktrace_files(stacktrace))
 
     def test_diff_contains_stacktrace_files_with_removed_file(self):
         # Mock the get_commit_file_diffs method to return changed and removed files
@@ -62,7 +62,7 @@ class TestContextManager(unittest.TestCase):
             ]
         )
         # Check if the diff contains stacktrace files
-        self.assertTrue(self.context_manager.diff_contains_stacktrace_files(stacktrace))
+        self.assertTrue(self.autofix_context.diff_contains_stacktrace_files(stacktrace))
 
     def test_diff_contains_stacktrace_files_raises_file_not_found(self):
         # Mock the get_commit_file_diffs method to raise FileNotFoundError
@@ -77,7 +77,7 @@ class TestContextManager(unittest.TestCase):
         )
         # Check if the diff contains stacktrace files raises FileNotFoundError
         with self.assertRaises(FileNotFoundError):
-            self.context_manager.diff_contains_stacktrace_files(stacktrace)
+            self.autofix_context.diff_contains_stacktrace_files(stacktrace)
 
 
 if __name__ == "__main__":

--- a/tests/automation/autofix/test_context_manager.py
+++ b/tests/automation/autofix/test_context_manager.py
@@ -1,0 +1,84 @@
+import unittest
+from unittest.mock import MagicMock
+
+from seer.automation.autofix.context_manager import ContextManager
+from seer.automation.autofix.models import Stacktrace, StacktraceFrame
+
+
+class TestContextManager(unittest.TestCase):
+    def setUp(self):
+        self.repo_owner = "seer"
+        self.repo_name = "automation"
+        self.base_sha = "abc123"
+        self.mock_repo_client = MagicMock()
+        self.context_manager = ContextManager(self.mock_repo_client, self.base_sha)
+
+    def test_diff_contains_stacktrace_files_with_intersection(self):
+        # Mock the get_commit_file_diffs method to return changed and removed files
+        self.mock_repo_client.get_commit_file_diffs.return_value = (
+            ["file1.py", "file2.py"],
+            ["file3.py"],
+        )
+        # Create a stacktrace with one of the files that has changed
+        stacktrace = Stacktrace(
+            frames=[
+                StacktraceFrame(
+                    filename="file2.py", col_no=0, line_no=10, function="test", context=[]
+                )
+            ]
+        )
+        # Check if the diff contains stacktrace files
+        self.assertTrue(self.context_manager.diff_contains_stacktrace_files(stacktrace))
+
+    def test_diff_contains_stacktrace_files_without_intersection(self):
+        # Mock the get_commit_file_diffs method to return changed and removed files
+        self.mock_repo_client.get_commit_file_diffs.return_value = (
+            ["file1.py", "file2.py"],
+            ["file3.py"],
+        )
+        # Create a stacktrace with files that have not changed
+        stacktrace = Stacktrace(
+            frames=[
+                StacktraceFrame(
+                    filename="file4.py", col_no=0, line_no=10, function="test", context=[]
+                )
+            ]
+        )
+        # Check if the diff contains stacktrace files
+        self.assertFalse(self.context_manager.diff_contains_stacktrace_files(stacktrace))
+
+    def test_diff_contains_stacktrace_files_with_removed_file(self):
+        # Mock the get_commit_file_diffs method to return changed and removed files
+        self.mock_repo_client.get_commit_file_diffs.return_value = (
+            ["file1.py"],
+            ["file2.py"],
+        )
+        # Create a stacktrace with a file that has been removed
+        stacktrace = Stacktrace(
+            frames=[
+                StacktraceFrame(
+                    filename="file2.py", col_no=0, line_no=10, function="test", context=[]
+                )
+            ]
+        )
+        # Check if the diff contains stacktrace files
+        self.assertTrue(self.context_manager.diff_contains_stacktrace_files(stacktrace))
+
+    def test_diff_contains_stacktrace_files_raises_file_not_found(self):
+        # Mock the get_commit_file_diffs method to raise FileNotFoundError
+        self.mock_repo_client.get_commit_file_diffs.side_effect = FileNotFoundError
+        # Create a stacktrace with any file
+        stacktrace = Stacktrace(
+            frames=[
+                StacktraceFrame(
+                    filename="file1.py", col_no=0, line_no=10, function="test", context=[]
+                )
+            ]
+        )
+        # Check if the diff contains stacktrace files raises FileNotFoundError
+        with self.assertRaises(FileNotFoundError):
+            self.context_manager.diff_contains_stacktrace_files(stacktrace)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Will short circuit and skip codebase index update step if the files in the stacktrace do not match the ones that changed since the last commit diff. This logic is part of the new codebase context overhaul to pgvector we are doing but this is done in advance in anticipation of higher volume on Monday.

Includes a lot of refactoring cleanup too + unit tests for the short circuiting!

Tested e2e with local Sentry App