### PR TITLE
chore(ai-autofix): update label for execution plan

### DIFF
--- a/src/seer/automation/autofix/event_manager.py
+++ b/src/seer/automation/autofix/event_manager.py
@@ -68,7 +68,7 @@ class AutofixEventManager:
                     Step(
                         id="plan",
                         index=2,
-                        title="Generate Execution Plan",
+                        title="Execution Plan",
                         status="PENDING",
                     ),
                 ]


### PR DESCRIPTION
make it consistent with how the other steps are presented

another option, @jennmueng i'll leave this up to you, we split this into two steps on the UI:
1. `Generating Execution Plan` (which is just a standalone step, similar to codebase indexing)
2. `Execution Plan` which populates with the actual plan after the above step finishes

^ is maybe a little bit more digestable but no strong feelings