### PR TITLE
feat(grouping): enable multi-project grouping support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ fonttools==4.42.1
 fsspec==2023.6.0
 gunicorn==20.1.0
 holidays==0.31
-huggingface-hub==0.16.4
 idna==3.4
 importlib-resources==6.0.1
 itsdangerous==2.1.2
@@ -40,18 +39,16 @@ pytz==2021.3
 PyYAML==6.0.1
 regex==2023.8.8
 requests==2.31.0
-safetensors==0.3.2
 scikit-learn==1.3.0
 scipy==1.11.2
 seaborn==0.12.2
-sentence_transformers==2.2.2
+sentence_transformers==2.3.1
 sentry-sdk==1.38.0
 simdkalman==1.0.2
 six==1.16.0
 statsmodels==0.14.0
 sympy==1.12
 threadpoolctl==3.2.0
-tokenizers==0.13.3
 torch==2.0.1
 tqdm==4.66.1
 typing_extensions==4.7.1
@@ -88,3 +85,4 @@ redis==5.0.1
 # deepsparse-nightly==1.7.0.20240103 TODO - fix pydantic conflict
 faiss-cpu==1.7.4
 unidiff==0.7.5
+transformers==4.37.2

--- a/src/seer/app.py
+++ b/src/seer/app.py
@@ -48,6 +48,8 @@ def embeddings_model() -> SeverityInference:
 
 @functools.cache
 def grouping_lookup() -> GroupingLookup:
+    if os.environ.get("GROUPING_ENABLED") != "true":
+        raise ValueError("Grouping is not enabled")
     return GroupingLookup(
         model_path="jinaai/jina-embeddings-v2-base-code",  # TODO: local .onnx model path
         data_path=model_path("issue_grouping_v0/data.pkl"),
@@ -130,5 +132,6 @@ register_json_api_views(app)
 def run(environ: dict, start_response: Callable) -> Any:
     # Force preload
     embeddings_model()
-    grouping_lookup()
+    if os.environ.get("GROUPING_ENABLED") == "true":
+        grouping_lookup()
     return app(environ, start_response)

--- a/src/seer/app.py
+++ b/src/seer/app.py
@@ -49,7 +49,7 @@ def embeddings_model() -> SeverityInference:
 @functools.cache
 def grouping_lookup() -> GroupingLookup:
     return GroupingLookup(
-        model_path=model_path("issue_grouping_v0/embeddings"),
+        model_path="jinaai/jina-embeddings-v2-base-code",  # TODO: local .onnx model path
         data_path=model_path("issue_grouping_v0/data.pkl"),
     )
 

--- a/src/seer/grouping/grouping.py
+++ b/src/seer/grouping/grouping.py
@@ -1,16 +1,17 @@
 import difflib
 import pickle
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 import faiss  # type: ignore
 import numpy as np
 import pandas as pd
-from pydantic import BaseModel, ValidationError, ValidationInfo, field_validator, validator
+from pydantic import BaseModel, ValidationInfo, field_validator, validator
 from sentence_transformers import SentenceTransformer
 
 
 class GroupingRequest(BaseModel):
     group_id: int
+    project_id: int
     stacktrace: str
     message: str
     k: int = 1
@@ -26,6 +27,7 @@ class GroupingRequest(BaseModel):
 
 class GroupingRecord(BaseModel):
     group_id: int
+    project_id: int
     stacktrace: str
     message: str
     embeddings: Any
@@ -60,8 +62,8 @@ class GroupingLookup:
 
     def __init__(self, model_path: str, data_path: str):
         """
-        Initializes the GroupingLookup with the model and preprocessed data. Generates
-        faiss index for similarity search.
+        Initializes the GroupingLookup with the model and preprocessed data. Creates
+        FAISS indexes for similarity search for each unique project ID in the dataset.
 
         Args:
             model_path (str): Path to the sentence transformer model.
@@ -70,10 +72,33 @@ class GroupingLookup:
         self.model = SentenceTransformer(model_path)
         with open(data_path, "rb") as file:
             self.data = pickle.load(file)
-        embeddings = np.vstack(self.data["embeddings"].values).astype("float32")
-        faiss.normalize_L2(embeddings)
-        self.index = faiss.IndexFlatIP(embeddings.shape[1])
-        self.index.add(embeddings)
+        self.indexes = self.create_indexes()
+
+    def create_indexes(self) -> Dict[int, faiss.IndexFlatIP]:
+        """
+        Creates FAISS indexes for each unique project ID in the provided dataset.
+
+        This method iterates over each unique project ID in the dataset, extracts the corresponding
+        embeddings, and creates a FAISS index for each project. The indexes are stored in a dictionary
+        with the project IDs as keys.
+
+        Args:
+            data (pd.DataFrame): The dataset containing stacktrace embeddings and project IDs.
+
+        Returns:
+            dict: A dictionary of FAISS indexes with project IDs as keys.
+        """
+        indexes = {}
+        for project_id in self.data["project_id"].unique():
+            project_embeddings = self.data[self.data["project_id"] == project_id][
+                "embeddings"
+            ].values
+            embeddings_matrix = np.vstack(project_embeddings).astype("float32")
+            faiss.normalize_L2(embeddings_matrix)
+            index = faiss.IndexFlatIP(embeddings_matrix.shape[1])
+            index.add(embeddings_matrix)
+            indexes[project_id] = index
+        return indexes
 
     def encode_text(self, stacktrace: str) -> np.ndarray:
         """
@@ -104,7 +129,7 @@ class GroupingLookup:
 
     def get_nearest_neighbors(self, issue: GroupingRequest) -> SimilarityResponse:
         """
-        Retrieves the k nearest neighbors for a stacktrace and determines if they should be grouped,
+        Retrieves the k nearest neighbors for a stacktrace within the same project and determines if they should be grouped,
         ensuring that an issue is not grouped with itself.
 
         Args:
@@ -115,6 +140,10 @@ class GroupingLookup:
             SimilarityResponse: A SimilarityResponse object containing a list of GroupingResponse objects with the nearest group IDs,
                                 stacktrace similarity scores, message similarity scores, and grouping flags.
         """
+        # Get the project data and index for the issue's project
+        project_data = self.data[self.data["project_id"] == issue.project_id]
+        index = self.indexes[issue.project_id]
+
         embedding = self.encode_text(issue.stacktrace).astype("float32")
         embedding = np.expand_dims(embedding, axis=0)
         # Find one extra neighbor to account for the issue itself

--- a/src/seer/grouping/grouping.py
+++ b/src/seer/grouping/grouping.py
@@ -69,7 +69,7 @@ class GroupingLookup:
             model_path (str): Path to the sentence transformer model.
             data_path (str): Path to the preprocessed data with stacktrace embeddings.
         """
-        self.model = SentenceTransformer(model_path)
+        self.model = SentenceTransformer(model_path, trust_remote_code=True)
         with open(data_path, "rb") as file:
             self.data = pickle.load(file)
         self.indexes = self.create_indexes()

--- a/src/seer/schemas/seer.py
+++ b/src/seer/schemas/seer.py
@@ -14,7 +14,7 @@ AutofixRequest = typing_extensions.TypedDict(
     "AutofixRequest",
     {
         "issue": "IssueDetails",
-        "base_commit_sha": typing.Union[str, None],
+        "base_commit_sha": str,
         "additional_context": typing.Union[str, None],
     },
     total=False,
@@ -84,6 +84,7 @@ GroupingRequest = typing_extensions.TypedDict(
     "GroupingRequest",
     {
         "group_id": int,
+        "project_id": int,
         "stacktrace": str,
         "message": str,
         # default: 1
@@ -108,7 +109,7 @@ GroupingResponse = typing_extensions.TypedDict(
 IssueDetails = typing_extensions.TypedDict(
     "IssueDetails",
     {
-        "id": str,
+        "id": int,
         "title": str,
         "events": typing.List["SentryEvent"],
     },

--- a/src/seer/schemas/seer_api.json
+++ b/src/seer/schemas/seer_api.json
@@ -148,14 +148,7 @@
             "$ref": "#/components/schemas/IssueDetails"
           },
           "base_commit_sha": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "string",
             "title": "Base Commit Sha"
           },
           "additional_context": {
@@ -173,8 +166,7 @@
         "type": "object",
         "required": [
           "issue",
-          "base_commit_sha",
-          "additional_context"
+          "base_commit_sha"
         ],
         "title": "AutofixRequest"
       },
@@ -384,6 +376,10 @@
             "type": "integer",
             "title": "Group Id"
           },
+          "project_id": {
+            "type": "integer",
+            "title": "Project Id"
+          },
           "stacktrace": {
             "type": "string",
             "title": "Stacktrace"
@@ -406,6 +402,7 @@
         "type": "object",
         "required": [
           "group_id",
+          "project_id",
           "stacktrace",
           "message"
         ],
@@ -449,7 +446,7 @@
       "IssueDetails": {
         "properties": {
           "id": {
-            "type": "string",
+            "type": "integer",
             "title": "Id"
           },
           "title": {


### PR DESCRIPTION
- expect additional `project_id` parameter
- use `project_id` to identify which embeddings cache to reference
- backend model changed to https://huggingface.co/jinaai/jina-embeddings-v2-base-code

updated code for indexing [here](https://github.com/getsentry/ml-models/blob/main/grouping/grouping_artifacts.ipynb)

note - there are some schema changes unrelated to my PR, which reflect prior changes that @jennmueng made to autofix (the `generate_schemas` script just hadnt been run since then)