### PR TITLE
Fixing gocd pipeline definition

### DIFF
--- a/gocd/pipelines/seer.yaml
+++ b/gocd/pipelines/seer.yaml
@@ -43,6 +43,8 @@ pipelines:
             - deploy:
                   jobs:
                     run-migrations:
+                      timeout: 1200
+                      elastic_profile_id: timeseries-analysis-service
                       tasks:
                         - script: |
                             echo "running flask db upgrade" \
@@ -57,19 +59,19 @@ pipelines:
                             db \
                             upgrade
 
-                      deploy:
-                          timeout: 1200
-                          elastic_profile_id: timeseries-analysis-service
-                          tasks:
-                              - script: |
-                                    /devinfra/scripts/k8s/k8stunnel \
-                                    && /devinfra/scripts/k8s/k8s-deploy.py \
-                                    --label-selector="service=seer" \
-                                    --image="us.gcr.io/sentryio/seer:${GO_REVISION_TIMESERIES_ANALYSIS_SERVICE_REPO}" \
-                                    --container-name="seer"
-                              - script: |
-                                    /devinfra/scripts/k8s/k8stunnel \
-                                    && /devinfra/scripts/k8s/k8s-deploy.py \
-                                    --label-selector="service=seer-autofix" \
-                                    --image="us.gcr.io/sentryio/seer:${GO_REVISION_TIMESERIES_ANALYSIS_SERVICE_REPO}" \
-                                    --container-name="seer-autofix"
+                    deploy:
+                        timeout: 1200
+                        elastic_profile_id: timeseries-analysis-service
+                        tasks:
+                            - script: |
+                                  /devinfra/scripts/k8s/k8stunnel \
+                                  && /devinfra/scripts/k8s/k8s-deploy.py \
+                                  --label-selector="service=seer" \
+                                  --image="us.gcr.io/sentryio/seer:${GO_REVISION_TIMESERIES_ANALYSIS_SERVICE_REPO}" \
+                                  --container-name="seer"
+                            - script: |
+                                  /devinfra/scripts/k8s/k8stunnel \
+                                  && /devinfra/scripts/k8s/k8s-deploy.py \
+                                  --label-selector="service=seer-autofix" \
+                                  --image="us.gcr.io/sentryio/seer:${GO_REVISION_TIMESERIES_ANALYSIS_SERVICE_REPO}" \
+                                  --container-name="seer-autofix"


### PR DESCRIPTION
https://deploy.getsentry.net/go/tab/build/detail/deploy-timeseries-analysis-service/89/deploy/1/run-migrations

Was hoping the gocd validation would have caught this, but it's an easy fix.