### PR TITLE
ref(langsmith): Disable langsmith in tests + label autofix chain as v1

### DIFF
--- a/src/seer/automation/autofix/autofix.py
+++ b/src/seer/automation/autofix/autofix.py
@@ -65,7 +65,7 @@ class Autofix:
 
         return True
 
-    @traceable(name="Autofix Run")
+    @traceable(name="Autofix Run", tags=["v1"])
     def run(self, run_tree: RunTree):
         metadata = run_tree.extra.get("metadata", {})
         metadata["request"] = self.request.model_dump()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 
 import pytest
 from sqlalchemy import text
@@ -10,6 +11,9 @@ from seer.tasks import AsyncSession
 
 @pytest.fixture(autouse=True)
 def manage_db():
+    # disables langsmith
+    os.environ["LANGCHAIN_TRACING_SAMPLING_RATE"] = "0"
+
     # Forces the initialization of the database
     from seer.app import app
 


### PR DESCRIPTION
Let's agree on:
- v0 (the original POC)
- v1 (this current version)
- v_n ....