### PR TITLE
Adding tasks framework for background processing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV APP_HOME /app
 WORKDIR $APP_HOME
 
 # Install supervisord
-RUN apt-get update && apt-get install -y supervisor && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y supervisor spell && rm -rf /var/lib/apt/lists/*
 
 # Copy model files (assuming they are in the 'models' directory)
 COPY models/ models/

--- a/requirements.txt
+++ b/requirements.txt
@@ -96,3 +96,4 @@ types-Flask-Migrate==4.0.0.20240205
 types-tree-sitter==0.20.1.20240106
 types-tree-sitter-languages==1.10.0.20240201
 langsmith==0.0.87
+pytest-asyncio==0.23.5

--- a/src/seer/bootup.py
+++ b/src/seer/bootup.py
@@ -42,5 +42,5 @@ def bootup(
         with app.app_context():
             Session.configure(bind=db.engine)
             if with_async:
-                AsyncSession.configure(bind=create_async_engine(db.engine.url))  # type: ignore
+                AsyncSession.configure(bind=create_async_engine(db.engine.url))
     return app

--- a/src/seer/bootup.py
+++ b/src/seer/bootup.py
@@ -1,0 +1,46 @@
+import os
+from typing import Collection
+
+import sentry_sdk
+from flask import Flask
+from sentry_sdk.integrations import Integration
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from seer.db import Session, db, migrate
+from seer.tasks import AsyncSession
+
+
+def traces_sampler(sampling_context: dict):
+    if "wsgi_environ" in sampling_context:
+        path_info = sampling_context["wsgi_environ"].get("PATH_INFO")
+        if path_info and path_info.startswith("/health/"):
+            return 0.0
+
+    return 1.0
+
+
+def bootup(
+    name: str,
+    plugins: Collection[Integration] = (),
+    init_migrations=False,
+    init_db=True,
+    with_async=False,
+) -> Flask:
+    sentry_sdk.init(
+        dsn=os.environ.get("SENTRY_DSN"),
+        integrations=[*plugins],
+        traces_sampler=traces_sampler,
+        profiles_sample_rate=1.0,
+        enable_tracing=True,
+    )
+    app = Flask(name)
+    app.config["SQLALCHEMY_DATABASE_URI"] = os.environ["DATABASE_URL"]
+    if init_db:
+        db.init_app(app)
+        if init_migrations:
+            migrate.init_app(app, db)
+        with app.app_context():
+            Session.configure(bind=db.engine)
+            if with_async:
+                AsyncSession.configure(bind=create_async_engine(db.engine.url))  # type: ignore
+    return app

--- a/src/seer/tasks.py
+++ b/src/seer/tasks.py
@@ -1,0 +1,155 @@
+import asyncio
+import dataclasses
+import datetime
+import multiprocessing
+from concurrent.futures import ThreadPoolExecutor
+from typing import Protocol, TypeVar
+
+from pydantic import BaseModel
+from sentry_sdk import start_span
+from sentry_sdk.integrations.asyncio import AsyncioIntegration
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from seer.db import ProcessRequest
+
+_Request = TypeVar("_Request", bound=BaseModel)
+_A = TypeVar("_A")
+
+AsyncSession = async_sessionmaker(expire_on_commit=False)
+
+
+class QConsumer(Protocol[_A]):
+    def get(self) -> _A:
+        ...
+
+
+class QProducer(Protocol[_A]):
+    def put(self, obj: _A) -> None:
+        ...
+
+
+class TaskFactory(Protocol[_Request]):
+    """
+    Represents a potential factory for mapping a process request to a local job to be invoked.
+    """
+
+    def from_process_request(self, process_request: ProcessRequest) -> _Request | None:
+        """
+        Selects a process request, usually by matching its name, to this task, returning a request
+        object from that job if it is a match.
+        """
+        pass
+
+    async def invoke(self, request: _Request):
+        pass
+
+
+@dataclasses.dataclass
+class AsyncApp:
+    end_event: asyncio.Event
+    queue: asyncio.Queue
+    io_work: QConsumer[ProcessRequest] = dataclasses.field(default_factory=multiprocessing.Queue)
+    cpu_work: QProducer[ProcessRequest] = dataclasses.field(default_factory=multiprocessing.Queue)
+    num_consumers: int = 10
+    task_factories: list[TaskFactory[BaseModel]] = dataclasses.field(
+        default_factory=lambda: [],
+    )
+    # workers = 2 => one for consuming io work, one for producing cpu_work
+    threaded_executor: ThreadPoolExecutor = dataclasses.field(
+        default_factory=lambda: ThreadPoolExecutor(max_workers=2)
+    )
+
+    async def select_from_db(self) -> None:
+        while not self.end_event.is_set():
+            loop = asyncio.get_event_loop()
+            loop.run_in_executor()
+            async with AsyncSession() as session:
+                work: list[ProcessRequest] = await session.run_sync(
+                    lambda session: ProcessRequest.acquire_work(
+                        100, datetime.datetime.utcnow(), session=session
+                    )
+                )
+                for item in work:
+                    await self.queue.put(item)
+
+            await asyncio.sleep(1)
+
+    async def select_from_local_work(self) -> None:
+        end_task = asyncio.create_task(self.end_event.wait())
+        while not self.end_event.is_set():
+            get_task = asyncio.get_running_loop().run_in_executor(
+                self.threaded_executor, self.io_work.get
+            )
+            await asyncio.wait([end_task, get_task], return_when=asyncio.FIRST_COMPLETED)
+            if end_task.done():
+                get_task.cancel()
+                await asyncio.gather(get_task, return_exceptions=True)
+                continue
+            item: ProcessRequest = get_task.result()
+            await self.queue.put(item)
+
+    async def producer_loop(self):
+        await asyncio.gather(self.select_from_db(), self.select_from_local_work())
+
+    async def consumer_loop(self):
+        end_task = asyncio.create_task(self.end_event.wait())
+        while not self.end_event.is_set():
+            get_task = asyncio.create_task(self.queue.get())
+            await asyncio.wait([get_task, end_task], return_when=asyncio.FIRST_COMPLETED)
+            if end_task.done():
+                get_task.cancel()
+                await asyncio.gather(get_task, return_exceptions=True)
+                continue
+
+            item: ProcessRequest = get_task.result()
+            for factory in self.task_factories:
+                request = factory.from_process_request(item)
+                if request is not None:
+                    # with hub.start_span(op=OP.FUNCTION, description=get_name(coro)):
+                    start_span
+                    await factory.invoke(request)
+
+                    # If this was persisted work, clean it up.
+                    if item.id:
+                        async with AsyncSession() as session:
+                            await session.execute(item.mark_completed_stmt())
+                            await session.commit()
+                    break
+
+    async def run(self):
+        producer_task = asyncio.create_task(self.producer_loop())
+        consumer_tasks: list[asyncio.Task[...]] = []
+        while not self.end_event.is_set():
+            if producer_task.done():
+                # Self terminate if the producer dies for any reason.
+                self.end_event.set()
+
+            task: asyncio.Task[...]
+            for task in [*consumer_tasks]:
+                if task.done():
+                    # Unexpected death of a task?  Reboot it.
+                    consumer_tasks.remove(task)
+
+            while len(consumer_tasks) < self.num_consumers:
+                consumer_tasks.append(asyncio.create_task(self.consumer_loop()))
+            await asyncio.sleep(1)
+
+        all_tasks = [producer_task, *consumer_tasks]
+        async with asyncio.timeout(10):
+            await asyncio.gather(*all_tasks)
+
+
+def main(work_ready: multiprocessing.Event = multiprocessing.Event()):
+    from seer.bootup import bootup
+
+    bootup(__name__, [AsyncioIntegration()])
+    app = AsyncApp(
+        end_event=asyncio.Event(),
+        queue=asyncio.Queue(),
+        work_ready=work_ready,
+    )
+    asyncio.run(app.run())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/seer/tasks.py
+++ b/src/seer/tasks.py
@@ -2,11 +2,12 @@ import asyncio
 import dataclasses
 import datetime
 import multiprocessing
+from asyncio import CancelledError, Future, Task
 from concurrent.futures import ThreadPoolExecutor
-from typing import Protocol, TypeVar
+from queue import Empty
+from typing import Any, Coroutine, Protocol, TypeVar
 
 from pydantic import BaseModel
-from sentry_sdk import start_span
 from sentry_sdk.integrations.asyncio import AsyncioIntegration
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
@@ -18,13 +19,13 @@ _A = TypeVar("_A")
 AsyncSession = async_sessionmaker(expire_on_commit=False)
 
 
-class QConsumer(Protocol[_A]):
-    def get(self) -> _A:
+class QConsumer(Protocol):
+    def get(self, block: bool = True, timeout: int | None = None) -> Any:
         ...
 
 
-class QProducer(Protocol[_A]):
-    def put(self, obj: _A) -> None:
+class QProducer(Protocol):
+    def put(self, obj: Any, block: bool = True, timeout: int | None = None) -> None:
         ...
 
 
@@ -48,8 +49,8 @@ class TaskFactory(Protocol[_Request]):
 class AsyncApp:
     end_event: asyncio.Event
     queue: asyncio.Queue
-    io_work: QConsumer[ProcessRequest] = dataclasses.field(default_factory=multiprocessing.Queue)
-    cpu_work: QProducer[ProcessRequest] = dataclasses.field(default_factory=multiprocessing.Queue)
+    io_work: QConsumer = dataclasses.field(default_factory=multiprocessing.Queue)
+    cpu_work: QProducer = dataclasses.field(default_factory=multiprocessing.Queue)
     num_consumers: int = 10
     task_factories: list[TaskFactory[BaseModel]] = dataclasses.field(
         default_factory=lambda: [],
@@ -59,54 +60,72 @@ class AsyncApp:
         default_factory=lambda: ThreadPoolExecutor(max_workers=2)
     )
 
+    async def run_or_end(self, c: Future[_A] | Coroutine[Any, Any, _A]) -> tuple[_A] | None:
+        end_task = asyncio.create_task(self.end_event.wait())
+        task: Future[_A] | Task[_A]
+        if not isinstance(c, Future):
+            task = asyncio.create_task(c)
+        else:
+            task = c
+        parts: list[Future | Task] = [end_task, task]
+        await asyncio.wait(parts, return_when=asyncio.FIRST_COMPLETED)
+        if end_task.done():
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+            return None
+        else:
+            end_task.cancel()
+        if exc := task.exception():
+            raise exc
+        return (task.result(),)
+
     async def select_from_db(self) -> None:
         while not self.end_event.is_set():
-            loop = asyncio.get_event_loop()
-            loop.run_in_executor()
             async with AsyncSession() as session:
-                work: list[ProcessRequest] = await session.run_sync(
-                    lambda session: ProcessRequest.acquire_work(
-                        100, datetime.datetime.utcnow(), session=session
+                result = await self.run_or_end(
+                    session.run_sync(
+                        lambda session: ProcessRequest.acquire_work(
+                            10, datetime.datetime.utcnow(), session=session
+                        )
                     )
                 )
-                for item in work:
-                    await self.queue.put(item)
+            if result is not None:
+                for item in result[0]:
+                    await self.run_or_end(self.queue.put(item))
+                    if self.end_event.is_set():
+                        break
+            else:
+                await self.run_or_end(asyncio.sleep(5))
 
-            await asyncio.sleep(1)
+    def get_io_work(self) -> ProcessRequest:
+        while not self.end_event.is_set():
+            try:
+                return self.io_work.get(True, 1)
+            except Empty:
+                pass
+        raise CancelledError()
 
     async def select_from_local_work(self) -> None:
-        end_task = asyncio.create_task(self.end_event.wait())
         while not self.end_event.is_set():
-            get_task = asyncio.get_running_loop().run_in_executor(
-                self.threaded_executor, self.io_work.get
+            result = await self.run_or_end(
+                asyncio.get_running_loop().run_in_executor(self.threaded_executor, self.get_io_work)
             )
-            await asyncio.wait([end_task, get_task], return_when=asyncio.FIRST_COMPLETED)
-            if end_task.done():
-                get_task.cancel()
-                await asyncio.gather(get_task, return_exceptions=True)
-                continue
-            item: ProcessRequest = get_task.result()
-            await self.queue.put(item)
+            if result is not None:
+                await self.run_or_end(self.queue.put(result[0]))
 
     async def producer_loop(self):
         await asyncio.gather(self.select_from_db(), self.select_from_local_work())
 
     async def consumer_loop(self):
-        end_task = asyncio.create_task(self.end_event.wait())
         while not self.end_event.is_set():
-            get_task = asyncio.create_task(self.queue.get())
-            await asyncio.wait([get_task, end_task], return_when=asyncio.FIRST_COMPLETED)
-            if end_task.done():
-                get_task.cancel()
-                await asyncio.gather(get_task, return_exceptions=True)
+            result = await self.run_or_end(self.queue.get())
+            if result is None:
                 continue
 
-            item: ProcessRequest = get_task.result()
+            item: ProcessRequest = result[0]
             for factory in self.task_factories:
                 request = factory.from_process_request(item)
                 if request is not None:
-                    # with hub.start_span(op=OP.FUNCTION, description=get_name(coro)):
-                    start_span
                     await factory.invoke(request)
 
                     # If this was persisted work, clean it up.
@@ -118,13 +137,14 @@ class AsyncApp:
 
     async def run(self):
         producer_task = asyncio.create_task(self.producer_loop())
-        consumer_tasks: list[asyncio.Task[...]] = []
+        consumer_tasks: list[asyncio.Task[Any]] = []
         while not self.end_event.is_set():
             if producer_task.done():
                 # Self terminate if the producer dies for any reason.
                 self.end_event.set()
+                continue
 
-            task: asyncio.Task[...]
+            task: asyncio.Task
             for task in [*consumer_tasks]:
                 if task.done():
                     # Unexpected death of a task?  Reboot it.
@@ -132,21 +152,20 @@ class AsyncApp:
 
             while len(consumer_tasks) < self.num_consumers:
                 consumer_tasks.append(asyncio.create_task(self.consumer_loop()))
-            await asyncio.sleep(1)
+            await self.run_or_end(asyncio.sleep(1))
 
         all_tasks = [producer_task, *consumer_tasks]
         async with asyncio.timeout(10):
             await asyncio.gather(*all_tasks)
 
 
-def main(work_ready: multiprocessing.Event = multiprocessing.Event()):
+def main():
     from seer.bootup import bootup
 
     bootup(__name__, [AsyncioIntegration()])
     app = AsyncApp(
         end_event=asyncio.Event(),
         queue=asyncio.Queue(),
-        work_ready=work_ready,
     )
     asyncio.run(app.run())
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import create_async_engine
@@ -22,3 +24,10 @@ def manage_db():
     finally:
         with app.app_context():
             db.metadata.drop_all(bind=db.engine)
+
+
+# @pytest.fixture(autouse=True)
+# def manage_async_errors():
+# asyncio.events.get_event_loop().set_exception_handler()
+
+pytest_plugins = ("pytest_asyncio",)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,214 @@
+import asyncio
+import dataclasses
+import datetime
+from typing import Annotated, Callable, Self
+
+import pytest
+from pydantic import BaseModel
+from sqlalchemy import select
+
+from seer.db import ProcessRequest, Session
+from seer.generator import Examples, gen, ints, parameterize, printable_strings
+from seer.tasks import AsyncApp, AsyncSession, TaskFactory
+
+
+@dataclasses.dataclass
+class ScheduledWork:
+    process_request: ProcessRequest
+
+    def save(self) -> Self:
+        with Session() as session:
+            session.add(self.process_request)
+            session.commit()
+        return self
+
+
+@dataclasses.dataclass
+class UpdatedWork:
+    scheduled_work: ScheduledWork
+    new_payload: Annotated[dict, Examples(({"this-unique-payload": i} for i in ints))]
+
+    @property
+    def original_process_request(self):
+        return self.scheduled_work.process_request
+
+    @property
+    def current_process_request_by_name(self):
+        with Session() as session:
+            return session.scalar(
+                select(ProcessRequest).where(
+                    ProcessRequest.name == self.original_process_request.name
+                )
+            )
+
+    def save(self, now: datetime.datetime) -> Self:
+        with Session() as session:
+            self.scheduled_work.save()
+            session.execute(
+                ProcessRequest.schedule_stmt(
+                    self.original_process_request.name, self.new_payload, now=now
+                )
+            )
+            session.commit()
+            return self
+
+
+@parameterize
+def test_schedule_is_idempotent(updated: UpdatedWork):
+    updated.save(datetime.datetime.now())
+    assert updated.current_process_request_by_name.payload == updated.new_payload
+    assert (
+        updated.current_process_request_by_name.scheduled_from
+        > updated.original_process_request.scheduled_from
+    )
+    assert (
+        updated.current_process_request_by_name.scheduled_for
+        == updated.current_process_request_by_name.scheduled_for
+    )
+
+
+@parameterize
+def test_mark_complete_does_not_erase_concurrent_work(updated: UpdatedWork):
+    updated.save(datetime.datetime.now() + datetime.timedelta(seconds=1))
+    with Session() as session:
+        session.execute(updated.original_process_request.mark_completed_stmt())
+
+    assert updated.current_process_request_by_name is not None
+
+    with Session() as session:
+        session.execute(updated.current_process_request_by_name.mark_completed_stmt())
+        session.commit()
+
+    assert updated.current_process_request_by_name is None
+
+
+@parameterize
+def test_next_schedule(
+    scheduled: tuple[ScheduledWork, ScheduledWork, ScheduledWork, ScheduledWork]
+):
+    for s in scheduled:
+        s.save()
+
+    work_1 = ProcessRequest.acquire_work(2, datetime.datetime.now())
+    assert len(work_1) == 2
+
+    work_2 = ProcessRequest.acquire_work(2, datetime.datetime.now())
+    assert len(work_2) == 2
+
+    assert len(ProcessRequest.acquire_work(4, datetime.datetime.now())) == 0
+
+    assert (
+        len(ProcessRequest.acquire_work(4, datetime.datetime.now() + datetime.timedelta(minutes=1)))
+        == 4
+    )
+    assert (
+        len(ProcessRequest.acquire_work(4, datetime.datetime.now() + datetime.timedelta(minutes=1)))
+        == 0
+    )
+
+    assert (
+        len(ProcessRequest.acquire_work(4, datetime.datetime.now() + datetime.timedelta(minutes=2)))
+        == 0
+    )
+    assert (
+        len(ProcessRequest.acquire_work(4, datetime.datetime.now() + datetime.timedelta(minutes=3)))
+        == 4
+    )
+
+
+@parameterize
+def test_next_schedule(scheduled: ScheduledWork):
+    scheduled.save()
+    proc = scheduled.process_request
+    now = proc.scheduled_from
+
+    proc.scheduled_for = next_time = proc.next_schedule(now)
+    assert next_time - now == datetime.timedelta(minutes=2)
+
+    proc.scheduled_for = next_time = proc.next_schedule(now)
+    assert next_time - now == datetime.timedelta(minutes=4)
+
+    proc.scheduled_for = next_time = proc.next_schedule(now)
+    assert next_time - now == datetime.timedelta(minutes=8)
+
+    proc.scheduled_for = next_time = proc.next_schedule(now)
+    assert next_time - now == datetime.timedelta(minutes=16)
+
+
+class TestRequest(BaseModel):
+    my_special_value: str
+
+
+class TestTaskFactory(TaskFactory[TestRequest]):
+    acceptible_names: frozenset[str] = frozenset(["job-1", "job-2", "job-3", "job-4"])
+    side_effect: Callable[[str], None] = lambda _: None
+
+    def from_process_request(self, process_request: ProcessRequest) -> TestRequest | None:
+        if process_request.name in self.acceptible_names:
+            return TestRequest(**process_request.payload)
+        return None
+
+    async def invoke(self, request: TestRequest):
+        self.side_effect(request.my_special_value)
+
+
+@dataclasses.dataclass
+class ScheduleAsyncTest:
+    acceptable_name: Annotated[str, Examples(gen.one_of(TestTaskFactory.acceptible_names))]
+    unacceptable_name: Annotated[
+        str, Examples((s for s in printable_strings if s not in TestTaskFactory.acceptible_names))
+    ]
+    payload: TestRequest
+    side_effect_calls: list[str] = dataclasses.field(default_factory=list)
+    end_event: asyncio.Event = dataclasses.field(default_factory=asyncio.Event)
+
+    def create_app(self) -> AsyncApp:
+        test_task = TestTaskFactory()
+        test_task.side_effect = lambda v: self.side_effect_calls.append(v)
+
+        return AsyncApp(
+            end_event=self.end_event,
+            queue=asyncio.Queue(),
+            task_factories=[
+                test_task,
+            ],
+            num_consumers=2,
+        )
+
+    async def current_process_request_by_name(self, name: str):
+        async with AsyncSession() as session:
+            return await session.scalar(select(ProcessRequest).where(ProcessRequest.name == name))
+
+    async def new_side_effect(self):
+        self.side_effect_calls = []
+        for _ in range(20):
+            await asyncio.sleep(0.1)
+            if self.side_effect_calls:
+                return self.side_effect_calls
+        raise ValueError(f"side effect of invoke was not invoked for 2 seconds")
+
+
+@pytest.mark.asyncio
+@parameterize
+async def test_next_schedule_async(test: ScheduleAsyncTest, now: datetime.datetime):
+    async with AsyncSession() as session:
+        for name in [test.acceptable_name, test.unacceptable_name]:
+            await session.execute(
+                ProcessRequest.schedule_stmt(name, test.payload.model_dump(), now=now)
+            )
+        await session.commit()
+
+    process = await test.current_process_request_by_name(test.acceptable_name)
+    assert process is not None
+
+    run_task = asyncio.create_task(test.create_app().run())
+    processed = await test.new_side_effect()
+    test.end_event.set()
+    await run_task
+    assert processed == [test.payload.my_special_value]
+
+    process = await test.current_process_request_by_name(test.acceptable_name)
+    assert process is None
+
+    process = await test.current_process_request_by_name(test.unacceptable_name)
+    assert process is not None


### PR DESCRIPTION
Cleaning up mypy and some failing tests (minor).  This is the starting place.

Next step will be integrating, slowly, the existing work of @jennmueng to make use of the async background process.

This framework supports a few things.
1.  Optional durable work queueing.  For work that should be retried indefinitely until it works, but coalesced so that multiple requests to do the work become one unit of that work (indexing).
2.  Ability to schedule work into an async processor from any context.  This can be remote (schedule work to be processed by any worker, durability preferred) or local (schedule work to be processed on this pod, latency preferred).
3.  Ability to even put GPU or CPU work off the celery queue.

Follow up will include using shared memory so that python services don't all load different copies of the same model on a pod.