### PR TITLE
fix(autofix): Fix planning step event not existing

### DIFF
--- a/src/seer/automation/autofix/autofix.py
+++ b/src/seer/automation/autofix/autofix.py
@@ -136,7 +136,6 @@ class Autofix:
                         logger.info(f"Codebase indexing scheduled for later")
                 else:
                     logger.debug(f"Codebase is up to date")
-                    self.event_manager.send_codebase_indexing_result(AutofixStatus.COMPLETED)
 
             if not self.context.codebases:
                 logger.warning(f"No codebase indexes")

--- a/src/seer/automation/autofix/event_manager.py
+++ b/src/seer/automation/autofix/event_manager.py
@@ -75,6 +75,18 @@ class AutofixEventManager:
         problem_discovery_step.status = AutofixStatus.COMPLETED
         self.steps = [
             problem_discovery_step,
+            Step(
+                id="codebase_indexing",
+                index=1,
+                title="Codebase Indexing",
+                status=AutofixStatus.PENDING,
+            ),
+            Step(
+                id="plan",
+                index=2,
+                title="Execution Plan",
+                status=AutofixStatus.PENDING,
+            ),
         ]
 
         self._send_steps_update(
@@ -83,57 +95,19 @@ class AutofixEventManager:
         logger.debug(f"Sent problem discovery result: {result}")
 
     def send_codebase_creation_message(self):
-        self.steps.extend(
-            [
-                Step(
-                    id="codebase_indexing",
-                    index=1,
-                    title="Codebase Indexing",
-                    description="This will take longer than usual because this is the first time you've run Autofix on this codebase.",
-                    status=AutofixStatus.PROCESSING,
-                ),
-                Step(
-                    id="plan",
-                    index=2,
-                    title="Execution Plan",
-                    status=AutofixStatus.PENDING,
-                ),
-            ]
+        indexing_step = next(step for step in self.steps if step.id == "codebase_indexing")
+
+        indexing_step.status = AutofixStatus.PROCESSING
+        indexing_step.description = (
+            "Creating initial codebase index for project, this may take a while..."
         )
 
         self._send_steps_update(AutofixStatus.PROCESSING)
 
     def send_codebase_indexing_message(self):
-        self.steps.extend(
-            [
-                Step(
-                    id="codebase_indexing",
-                    index=1,
-                    title="Codebase Indexing",
-                    status=AutofixStatus.PROCESSING,
-                ),
-                Step(
-                    id="plan",
-                    index=2,
-                    title="Execution Plan",
-                    status=AutofixStatus.PENDING,
-                ),
-            ]
-        )
+        indexing_step = next(step for step in self.steps if step.id == "codebase_indexing")
 
-        self._send_steps_update(AutofixStatus.PROCESSING)
-
-    def send_codebase_creation_skip(self):
-        self.steps.extend(
-            [
-                Step(
-                    id="plan",
-                    index=1,
-                    title="Execution Plan",
-                    status=AutofixStatus.PENDING,
-                ),
-            ]
-        )
+        indexing_step.status = AutofixStatus.PROCESSING
 
         self._send_steps_update(AutofixStatus.PROCESSING)
 


### PR DESCRIPTION
Re-organize the event steps as we were hitting an error where the plan step didn't exist in the `next(...`