### PR TITLE
Only commit schema changes from master

### DIFF
--- a/.github/workflows/commit-schemas.yml
+++ b/.github/workflows/commit-schemas.yml
@@ -3,7 +3,6 @@ name: Commit schema updates
 on:
   push:
     branches: [ main ]
-  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
Small adjustment so that PRs aren't updating our official json schemas, only master merged work is.