### PR TITLE
build: Use cuda-supported docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN chmod +x ./celeryworker.sh
 
 # Install dependencies
 RUN pip install --upgrade pip==23.0.1
-RUN pip install -r requirements.txt --ignore-installed blinker
+RUN pip install -r requirements.txt
 
 # Then install psycopg
 RUN pip install psycopg[binary]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11
+FROM nvidia/cuda:12.3.2-cudnn9-runtime-ubuntu22.04
 
 # Allow statements and log messages to immediately appear in the Cloud Run logs
 ARG TEST
@@ -10,8 +10,18 @@ ENV PORT=$PORT
 ENV APP_HOME /app
 WORKDIR $APP_HOME
 
+# Install Python and pip
+RUN apt-get update && apt-get install -y software-properties-common && add-apt-repository ppa:deadsnakes/ppa
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y python3.11 python3-pip
+
 # Install supervisord
-RUN apt-get update && apt-get install -y supervisor spell && rm -rf /var/lib/apt/lists/*
+RUN apt-get install -y supervisor spell
+
+# Install libpq-dev for psycopg
+RUN apt-get update && apt-get install -y libpq-dev
+
+# Clean up
+RUN rm -rf /var/lib/apt/lists/*
 
 # Copy model files (assuming they are in the 'models' directory)
 COPY models/ models/
@@ -24,7 +34,10 @@ RUN chmod +x ./celeryworker.sh
 
 # Install dependencies
 RUN pip install --upgrade pip==23.0.1
-RUN pip install -r requirements.txt
+RUN pip install -r requirements.txt --ignore-installed blinker
+
+# Then install psycopg
+RUN pip install psycopg[binary]
 
 # Copy source code
 COPY src/ src/

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,6 @@ RUN chmod +x ./celeryworker.sh
 RUN pip install --upgrade pip==23.0.1
 RUN pip install -r requirements.txt
 
-# Then install psycopg
-RUN pip install psycopg[binary]
-
 # Copy source code
 COPY src/ src/
 COPY pyproject.toml .

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,11 @@ WORKDIR $APP_HOME
 
 # Install Python and pip
 RUN apt-get update && apt-get install -y software-properties-common && add-apt-repository ppa:deadsnakes/ppa
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y python3.11 python3-pip
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y python3.11 python3-pip python3.11-dev
+
+# Make python3.11 the default python version if necessary
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1 && \
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
 
 # Install supervisord
 RUN apt-get install -y supervisor spell

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.3.2-cudnn9-runtime-ubuntu22.04
+FROM nvidia/cuda:12.3.2-base-ubuntu22.04
 
 # Allow statements and log messages to immediately appear in the Cloud Run logs
 ARG TEST

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@ update: .env # Updates the project's docker-compose image.
 dev: .env # Starts the webserver based on the current src on port 9091
 	docker-compose up --build
 
+.PHONY: dev-cuda
+dev-cuda: .env # Starts the webserver based on the current src on port 9091 with cuda enabled
+	docker-compose -f docker-compose.yml -f docker-compose.cuda.yml up --build
+
 .PHONY: test
 test: # Executes all tests in the baked image file.  Requires models/
 	docker-compose run app mypy

--- a/docker-compose.cuda.yml
+++ b/docker-compose.cuda.yml
@@ -1,0 +1,8 @@
+services:
+    app:
+        deploy:
+            resources:
+                reservations:
+                    devices:
+                        - driver: nvidia
+                          capabilities: [gpu]

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,7 +57,6 @@ tzdata==2023.3
 tree_sitter_languages==1.9.1
 urllib3==1.26.16
 Werkzeug==2.3.7
-blinker==1.6.2
 pre-commit==3.5.0
 black==23.10.1
 isort==5.12.0


### PR DESCRIPTION
Running `make dev-cuda` will run docker-compose with gpus enabled