### PR TITLE
fix(ai-autofix): Accept git repo provider format from sentry

### DIFF
--- a/src/seer/automation/autofix/models.py
+++ b/src/seer/automation/autofix/models.py
@@ -140,7 +140,7 @@ class IssueDetails(BaseModel):
 
 
 class RepoDefinition(BaseModel):
-    provider: Literal["github"]
+    provider: str
     owner: str
     name: str
 

--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -57,6 +57,7 @@ class RepoClient:
         repo_owner: str,
         repo_name: str,
     ):
+        repo_provider = self._process_repo_provider(repo_provider)
         if repo_provider != "github":
             # This should never get here, the repo provider should be checked on the Sentry side but this will make debugging
             # easier if it does
@@ -70,6 +71,11 @@ class RepoClient:
 
         self.repo_owner = repo_owner
         self.repo_name = repo_name
+
+    def _process_repo_provider(self, provider: str) -> str:
+        if provider.startswith("integrations:"):
+            return provider.split(":")[1]
+        return provider
 
     def get_default_branch(self):
         return self.repo.default_branch

--- a/tests/automation/codebase/test_repo_client.py
+++ b/tests/automation/codebase/test_repo_client.py
@@ -1,0 +1,45 @@
+import unittest
+from unittest.mock import patch
+
+from seer.automation.codebase.repo_client import RepoClient
+from seer.automation.models import InitializationError
+
+
+class TestRepoClient(unittest.TestCase):
+    @patch("seer.automation.codebase.repo_client.Github")
+    @patch("seer.automation.codebase.repo_client.get_github_auth")
+    def test_repo_client_accepts_github_provider(self, mock_get_github_auth, mock_github):
+        # Mocking Github class and get_github_auth function to simulate GitHub API responses and authentication
+        mock_github_instance = mock_github.return_value
+        mock_github_instance.get_repo.return_value.default_branch = "main"
+        mock_get_github_auth.return_value = (
+            None  # Assuming get_github_auth returns None for simplicity
+        )
+        client = RepoClient(repo_provider="github", repo_owner="test_owner", repo_name="test_repo")
+        self.assertEqual(client.provider, "github")
+
+    @patch("seer.automation.codebase.repo_client.Github")
+    @patch("seer.automation.codebase.repo_client.get_github_auth")
+    def test_repo_client_accepts_integrations_github_provider(
+        self, mock_get_github_auth, mock_github
+    ):
+        # Mocking Github class and get_github_auth function to simulate GitHub API responses and authentication
+        mock_github_instance = mock_github.return_value
+        mock_github_instance.get_repo.return_value.default_branch = "main"
+        mock_get_github_auth.return_value = (
+            None  # Assuming get_github_auth returns None for simplicity
+        )
+        client = RepoClient(
+            repo_provider="integrations:github", repo_owner="test_owner", repo_name="test_repo"
+        )
+        self.assertEqual(client.provider, "github")
+
+    @patch("seer.automation.codebase.repo_client.get_github_auth")
+    def test_repo_client_rejects_unsupported_provider(self, mock_get_github_auth):
+        mock_get_github_auth.return_value = (
+            None  # Assuming get_github_auth returns None for simplicity
+        )
+        with self.assertRaises(InitializationError):
+            RepoClient(
+                repo_provider="unsupported_provider", repo_owner="test_owner", repo_name="test_repo"
+            )


### PR DESCRIPTION
Sentry side repo providers come in the format `integrations:github` etc

Fixes [TIMESERIES-ANALYSIS-SERVICE-2N](https://sentry.sentry.io/issues/5028696400/)