### PR TITLE
fix(ai-autofix): Validate duplicate repos in autofix request

### DIFF
--- a/tests/automation/autofix/test_models.py
+++ b/tests/automation/autofix/test_models.py
@@ -1,6 +1,15 @@
 import unittest
 
-from seer.automation.autofix.models import Stacktrace, StacktraceFrame
+from pydantic import ValidationError
+
+from seer.automation.autofix.models import (
+    AutofixRequest,
+    IssueDetails,
+    RepoDefinition,
+    SentryEvent,
+    Stacktrace,
+    StacktraceFrame,
+)
 
 
 class TestStacktraceHelpers(unittest.TestCase):
@@ -83,3 +92,66 @@ class TestStacktraceHelpers(unittest.TestCase):
             is_suspect_line = ctx[0] == frame.line_no
             stack_str += f"{ctx[1]}{'  <-- SUSPECT LINE' if is_suspect_line else ''}\n"
         self.assertEqual(stack_str, expected_str)
+
+
+class TestRepoDefinition(unittest.TestCase):
+    def test_repo_definition_creation(self):
+        repo_def = RepoDefinition(provider="github", owner="seer", name="automation")
+        self.assertEqual(repo_def.provider, "github")
+        self.assertEqual(repo_def.owner, "seer")
+        self.assertEqual(repo_def.name, "automation")
+
+    def test_repo_definition_uniqueness(self):
+        repo_def1 = RepoDefinition(provider="github", owner="seer", name="automation")
+        repo_def2 = RepoDefinition(provider="github", owner="seer", name="automation")
+        self.assertEqual(hash(repo_def1), hash(repo_def2))
+
+    def test_multiple_repos(self):
+        repo_def1 = RepoDefinition(provider="github", owner="seer", name="automation")
+        repo_def2 = RepoDefinition(provider="bitbucket", owner="seer", name="automation-tools")
+        self.assertNotEqual(hash(repo_def1), hash(repo_def2))
+
+    def test_repo_with_none_provider(self):
+        repo_dict = {"provider": None, "owner": "seer", "name": "automation"}
+        with self.assertRaises(ValidationError):
+            RepoDefinition(**repo_dict)
+
+
+class TestAutofixRequest(unittest.TestCase):
+    def test_autofix_request_handler(self):
+        repo_def = RepoDefinition(provider="github", owner="seer", name="automation")
+        issue_details = IssueDetails(id=789, title="Test Issue", events=[SentryEvent(entries=[])])
+        autofix_request = AutofixRequest(
+            organization_id=123,
+            project_id=456,
+            repos=[repo_def],
+            issue=issue_details,
+        )
+        self.assertEqual(autofix_request.organization_id, 123)
+        self.assertEqual(autofix_request.project_id, 456)
+        self.assertEqual(len(autofix_request.repos), 1)
+        self.assertEqual(autofix_request.issue.id, 789)
+        self.assertEqual(autofix_request.issue.title, "Test Issue")
+
+    def test_autofix_request_with_duplicate_repos(self):
+        repo_def1 = RepoDefinition(provider="github", owner="seer", name="automation")
+        repo_def2 = RepoDefinition(provider="github", owner="seer", name="automation")
+        with self.assertRaises(ValidationError):
+            AutofixRequest(
+                organization_id=123,
+                project_id=456,
+                repos=[repo_def1, repo_def2],
+                issue=IssueDetails(id=789, title="Test Issue", events=[SentryEvent(entries=[])]),
+            )
+
+    def test_autofix_request_with_multiple_repos(self):
+        repo_def1 = RepoDefinition(provider="github", owner="seer", name="automation")
+        repo_def2 = RepoDefinition(provider="bitbucket", owner="seer", name="automation-tools")
+        issue_details = IssueDetails(id=789, title="Test Issue", events=[SentryEvent(entries=[])])
+        autofix_request = AutofixRequest(
+            organization_id=123,
+            project_id=456,
+            repos=[repo_def1, repo_def2],
+            issue=issue_details,
+        )
+        self.assertEqual(len(autofix_request.repos), 2)


### PR DESCRIPTION
Validate that there are no duplicate repository definitions in a request. Duplicates will be pruned on the sentry side.