### PR TITLE
ref(ai-autofix): Better design for document chunk models

### DIFF
--- a/src/seer/automation/autofix/autofix.py
+++ b/src/seer/automation/autofix/autofix.py
@@ -32,7 +32,7 @@ from seer.automation.autofix.prompts import (
 )
 from seer.automation.autofix.tools import BaseTools, CodeActionTools
 from seer.automation.autofix.utils import escape_multi_xml, extract_xml_element_text
-from seer.automation.codebase.models import DocumentChunkWithEmbedding
+from seer.automation.codebase.models import StoredDocumentChunk
 from seer.automation.codebase.tasks import update_codebase_index
 
 logger = logging.getLogger("autofix")
@@ -457,7 +457,7 @@ class Autofix:
             return ""
 
         context_dump = ""
-        unique_chunks: dict[str, DocumentChunkWithEmbedding] = {}
+        unique_chunks: dict[str, StoredDocumentChunk] = {}
         for query in queries:
             retrived_chunks = self.context.query(query, top_k=4)
             for chunk in retrived_chunks:

--- a/src/seer/automation/autofix/autofix_context.py
+++ b/src/seer/automation/autofix/autofix_context.py
@@ -2,7 +2,7 @@ import uuid
 
 from seer.automation.autofix.models import RepoDefinition, Stacktrace
 from seer.automation.codebase.codebase_index import CodebaseIndex
-from seer.automation.codebase.models import DocumentChunkWithEmbeddingAndId
+from seer.automation.codebase.models import StoredDocumentChunk
 from seer.automation.utils import get_embedding_model
 from seer.db import DbDocumentChunk, Session
 
@@ -80,7 +80,7 @@ class AutofixContext:
             for db_chunk in db_chunks:
                 chunks_by_repo_id.setdefault(db_chunk.repo_id, []).append(db_chunk)
 
-            populated_chunks: list[DocumentChunkWithEmbeddingAndId] = []
+            populated_chunks: list[StoredDocumentChunk] = []
             for _repo_id, db_chunks in chunks_by_repo_id.items():
                 codebase = self.get_codebase(_repo_id)
                 populated_chunks.extend(codebase._populate_chunks(db_chunks))

--- a/src/seer/automation/codebase/models.py
+++ b/src/seer/automation/codebase/models.py
@@ -10,11 +10,10 @@ from seer.db import DbDocumentChunk, DbRepositoryInfo
 class Document(BaseModel):
     path: str
     text: str
-    repo_id: int
     language: str
 
 
-class DocumentChunk(BaseModel):
+class BaseDocumentChunk(BaseModel):
     id: Optional[int] = None
     content: str
     context: Optional[str]
@@ -23,7 +22,6 @@ class DocumentChunk(BaseModel):
     path: str
     index: int
     token_count: int
-    repo_id: int
 
     def get_dump_for_embedding(self):
         return """{context}{content}""".format(
@@ -58,13 +56,13 @@ class DocumentChunk(BaseModel):
         return self.__str__()
 
 
-class DocumentChunkWithEmbedding(DocumentChunk):
+class EmbeddedDocumentChunk(BaseDocumentChunk):
     embedding: np.ndarray
 
-    def to_db_model(self) -> DbDocumentChunk:
+    def to_db_model(self, repo_id: int) -> DbDocumentChunk:
         return DbDocumentChunk(
             id=self.id,
-            repo_id=self.repo_id,
+            repo_id=repo_id,
             path=self.path,
             index=self.index,
             hash=self.hash,
@@ -80,8 +78,9 @@ class DocumentChunkWithEmbedding(DocumentChunk):
         }
 
 
-class DocumentChunkWithEmbeddingAndId(DocumentChunkWithEmbedding):
+class StoredDocumentChunk(EmbeddedDocumentChunk):
     id: int
+    repo_id: int
 
 
 class RepositoryInfo(BaseModel):

--- a/src/seer/automation/codebase/utils.py
+++ b/src/seer/automation/codebase/utils.py
@@ -76,7 +76,6 @@ def get_language_from_path(path: str) -> str | None:
 
 def read_directory(
     path: str,
-    repo_id: int,
     parent_tmp_dir: str | None = None,
     max_file_size=2 * 1024 * 1024,  # 2 MB
 ) -> list[Document]:
@@ -92,7 +91,7 @@ def read_directory(
     dir_children = []
     for entry in os.scandir(path):
         if entry.is_dir(follow_symlinks=False):
-            dir_children.extend(read_directory(entry.path, repo_id, path_to_remove))
+            dir_children.extend(read_directory(entry.path, path_to_remove))
         elif entry.is_file() and entry.stat().st_size < max_file_size:
             language = get_language_from_path(entry.path)
 
@@ -108,13 +107,11 @@ def read_directory(
             if truncated_path.startswith("/"):
                 truncated_path = truncated_path[1:]
 
-            dir_children.append(
-                Document(path=truncated_path, text=text, repo_id=repo_id, language=language)
-            )
+            dir_children.append(Document(path=truncated_path, text=text, language=language))
     return dir_children
 
 
-def read_specific_files(repo_path: str, files: list[str], repo_id: int) -> list[Document]:
+def read_specific_files(repo_path: str, files: list[str]) -> list[Document]:
     """
     Reads the contents of specific files and returns a list of Document objects.
 
@@ -134,7 +131,7 @@ def read_specific_files(repo_path: str, files: list[str], repo_id: int) -> list[
         with open(file_path, "r", encoding="utf-8") as f:
             text = f.read()
 
-        documents.append(Document(path=file, text=text, repo_id=repo_id, language=language))
+        documents.append(Document(path=file, text=text, language=language))
     return documents
 
 

--- a/tests/automation/codebase/test_parser.py
+++ b/tests/automation/codebase/test_parser.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 from sentence_transformers import SentenceTransformer
 from tree_sitter import Node, Parser
 
-from seer.automation.codebase.models import DocumentChunk
+from seer.automation.codebase.models import BaseDocumentChunk
 from seer.automation.codebase.parser import Document, DocumentParser, ParentDeclaration, TempChunk
 
 
@@ -23,7 +23,7 @@ class TestDocumentParser(unittest.TestCase):
         mock_document.path = "test.py"
         mock_document.repo_id = 1
 
-        expected_chunks = [MagicMock(spec=DocumentChunk)]
+        expected_chunks = [MagicMock(spec=BaseDocumentChunk)]
         self.document_parser.process_document = MagicMock(return_value=expected_chunks)
 
         result_chunks = self.document_parser.process_document(mock_document)
@@ -33,7 +33,7 @@ class TestDocumentParser(unittest.TestCase):
     def test_document_parser_process_documents(self):
         # Test processing of multiple documents
         mock_documents = [MagicMock(spec=Document) for _ in range(2)]
-        expected_chunks = [MagicMock(spec=DocumentChunk), MagicMock(spec=DocumentChunk)]
+        expected_chunks = [MagicMock(spec=BaseDocumentChunk), MagicMock(spec=BaseDocumentChunk)]
         self.document_parser.process_documents = MagicMock(return_value=expected_chunks)
 
         result_chunks = self.document_parser.process_documents(mock_documents)


### PR DESCRIPTION
Attempts to fix [TIMESERIES-ANALYSIS-SERVICE-2S](https://sentry.sentry.io/issues/5029600041/)

Refactors the document chunk models to not need a `repo_id` in the base model (now renamed `BaseDocumentChunk`) while ones with embeddings are now `EmbeddedDocumentChunk` and the one that has been retrieved from db is `StoredDocumentChunk`.

This way it is clearer that you're working with `StoredDocumentChunk` when retrieving from the database and the former two models are transitional and only used when processing chunks.