### PR TITLE
chore(autofix): Revert the embedding batch size to 4

### DIFF
--- a/src/seer/automation/codebase/codebase_index.py
+++ b/src/seer/automation/codebase/codebase_index.py
@@ -212,7 +212,7 @@ class CodebaseIndex:
             for i in range(0, len(chunks), superchunk_size := 128):
                 batch_embeddings: np.ndarray = get_embedding_model().encode(
                     [chunk.get_dump_for_embedding() for chunk in chunks[i : i + superchunk_size]],
-                    batch_size=1,
+                    batch_size=4,
                     show_progress_bar=True,
                 )
                 embeddings_list.extend(batch_embeddings)


### PR DESCRIPTION
We reverted to 1 when we were cpu/memory constrained, now we aren't

(4 worked well on L4 in my experiments)