### PR TITLE
fix(autofix): Fix repo provider name for repo info query

### DIFF
--- a/src/seer/automation/codebase/codebase_index.py
+++ b/src/seer/automation/codebase/codebase_index.py
@@ -69,20 +69,21 @@ class CodebaseIndex:
     def from_repo_definition(
         cls, organization: int, project: int, repo: RepoDefinition, run_id: uuid.UUID
     ):
+        provider = RepoClient.process_repo_provider(repo.provider)
         db_repo_info = (
             Session()
             .query(DbRepositoryInfo)
             .filter(
                 DbRepositoryInfo.organization == organization,
                 DbRepositoryInfo.project == project,
-                DbRepositoryInfo.provider == repo.provider,
+                DbRepositoryInfo.provider == provider,
                 DbRepositoryInfo.external_slug == f"{repo.owner}/{repo.name}",
             )
             .one_or_none()
         )
         if db_repo_info:
             repo_info = RepositoryInfo.from_db(db_repo_info)
-            repo_client = RepoClient(repo.provider, repo.owner, repo.name)
+            repo_client = RepoClient(provider, repo.owner, repo.name)
             return cls(organization, project, repo_client, repo_info, run_id)
 
         return None

--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -57,7 +57,6 @@ class RepoClient:
         repo_owner: str,
         repo_name: str,
     ):
-        repo_provider = self._process_repo_provider(repo_provider)
         if repo_provider != "github":
             # This should never get here, the repo provider should be checked on the Sentry side but this will make debugging
             # easier if it does
@@ -72,7 +71,8 @@ class RepoClient:
         self.repo_owner = repo_owner
         self.repo_name = repo_name
 
-    def _process_repo_provider(self, provider: str) -> str:
+    @staticmethod
+    def process_repo_provider(provider: str) -> str:
         if provider.startswith("integrations:"):
             return provider.split(":")[1]
         return provider

--- a/tests/automation/codebase/test_repo_client.py
+++ b/tests/automation/codebase/test_repo_client.py
@@ -18,22 +18,6 @@ class TestRepoClient(unittest.TestCase):
         client = RepoClient(repo_provider="github", repo_owner="test_owner", repo_name="test_repo")
         self.assertEqual(client.provider, "github")
 
-    @patch("seer.automation.codebase.repo_client.Github")
-    @patch("seer.automation.codebase.repo_client.get_github_auth")
-    def test_repo_client_accepts_integrations_github_provider(
-        self, mock_get_github_auth, mock_github
-    ):
-        # Mocking Github class and get_github_auth function to simulate GitHub API responses and authentication
-        mock_github_instance = mock_github.return_value
-        mock_github_instance.get_repo.return_value.default_branch = "main"
-        mock_get_github_auth.return_value = (
-            None  # Assuming get_github_auth returns None for simplicity
-        )
-        client = RepoClient(
-            repo_provider="integrations:github", repo_owner="test_owner", repo_name="test_repo"
-        )
-        self.assertEqual(client.provider, "github")
-
     @patch("seer.automation.codebase.repo_client.get_github_auth")
     def test_repo_client_rejects_unsupported_provider(self, mock_get_github_auth):
         mock_get_github_auth.return_value = (
@@ -43,3 +27,8 @@ class TestRepoClient(unittest.TestCase):
             RepoClient(
                 repo_provider="unsupported_provider", repo_owner="test_owner", repo_name="test_repo"
             )
+
+    def test_repo_client_process_repo_provider(self):
+        assert RepoClient.process_repo_provider("github") == "github"
+        assert RepoClient.process_repo_provider("integrations:github") == "github"
+        assert RepoClient.process_repo_provider("integrations:bitbucket") == "bitbucket"


### PR DESCRIPTION
Sentry's provider values come in as `integrations:github` etc