### PR TITLE
ref(autofix): Move repo provider processing + validation logic to model

### DIFF
--- a/src/seer/automation/autofix/models.py
+++ b/src/seer/automation/autofix/models.py
@@ -144,6 +144,18 @@ class RepoDefinition(BaseModel):
     owner: str
     name: str
 
+    @field_validator("provider", mode="after")
+    @classmethod
+    def validate_provider(cls, provider: str):
+        cleaned_provider = provider
+        if provider.startswith("integrations:"):
+            cleaned_provider = provider.split(":")[1]
+
+        if cleaned_provider != "github":
+            raise ValueError(f"Provider {cleaned_provider} is not supported.")
+
+        return cleaned_provider
+
     def __hash__(self):
         return hash((self.provider, self.owner, self.name))
 

--- a/src/seer/automation/codebase/codebase_index.py
+++ b/src/seer/automation/codebase/codebase_index.py
@@ -69,21 +69,20 @@ class CodebaseIndex:
     def from_repo_definition(
         cls, organization: int, project: int, repo: RepoDefinition, run_id: uuid.UUID
     ):
-        provider = RepoClient.process_repo_provider(repo.provider)
         db_repo_info = (
             Session()
             .query(DbRepositoryInfo)
             .filter(
                 DbRepositoryInfo.organization == organization,
                 DbRepositoryInfo.project == project,
-                DbRepositoryInfo.provider == provider,
+                DbRepositoryInfo.provider == repo.provider,
                 DbRepositoryInfo.external_slug == f"{repo.owner}/{repo.name}",
             )
             .one_or_none()
         )
         if db_repo_info:
             repo_info = RepositoryInfo.from_db(db_repo_info)
-            repo_client = RepoClient(provider, repo.owner, repo.name)
+            repo_client = RepoClient(repo.provider, repo.owner, repo.name)
             return cls(organization, project, repo_client, repo_info, run_id)
 
         return None

--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -71,12 +71,6 @@ class RepoClient:
         self.repo_owner = repo_owner
         self.repo_name = repo_name
 
-    @staticmethod
-    def process_repo_provider(provider: str) -> str:
-        if provider.startswith("integrations:"):
-            return provider.split(":")[1]
-        return provider
-
     def get_default_branch(self):
         return self.repo.default_branch
 

--- a/tests/automation/autofix/test_models.py
+++ b/tests/automation/autofix/test_models.py
@@ -165,15 +165,3 @@ class TestAutofixRequest(unittest.TestCase):
             issue=issue_details,
         )
         self.assertEqual(len(autofix_request.repos), 2)
-
-    def test_autofix_request_with_invalid_repo(self):
-        repo_def1 = RepoDefinition(provider="github", owner="seer", name="automation")
-        repo_def2 = RepoDefinition(provider="bitbucket", owner="seer", name="automation-tools")
-        issue_details = IssueDetails(id=789, title="Test Issue", events=[SentryEvent(entries=[])])
-        with self.assertRaises(ValidationError):
-            AutofixRequest(
-                organization_id=123,
-                project_id=456,
-                repos=[repo_def1, repo_def2],
-                issue=issue_details,
-            )

--- a/tests/automation/codebase/test_repo_client.py
+++ b/tests/automation/codebase/test_repo_client.py
@@ -27,8 +27,3 @@ class TestRepoClient(unittest.TestCase):
             RepoClient(
                 repo_provider="unsupported_provider", repo_owner="test_owner", repo_name="test_repo"
             )
-
-    def test_repo_client_process_repo_provider(self):
-        assert RepoClient.process_repo_provider("github") == "github"
-        assert RepoClient.process_repo_provider("integrations:github") == "github"
-        assert RepoClient.process_repo_provider("integrations:bitbucket") == "bitbucket"


### PR DESCRIPTION
Move repo validation logic to where it should be, so we don't get any leftover unprocessed repo provider values