### PR TITLE
feat(autofix): Output a diff with autofix result

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,9 @@ module = [
     "scipy.*",
     "openai_multi_tool_use_parallel_patch",
     "fsspec",
-    "unidiff"
+    "unidiff",
+    "tree_sitter_languages",
+    "tree_sitter"
 ]
 ignore_missing_imports = true
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,7 +54,7 @@ torch==2.0.1
 tqdm==4.66.1
 typing_extensions==4.7.1
 tzdata==2023.3
-tree_sitter_languages==1.9.1
+tree_sitter_languages==1.10.2
 urllib3==1.26.16
 Werkzeug==2.3.7
 pre-commit==3.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -91,8 +91,6 @@ sqlalchemy==2.0.25
 Flask-Migrate==4.0.5
 Flask-SQLAlchemy==3.1.1
 types-Flask-Migrate==4.0.0.20240205
-types-tree-sitter==0.20.1.20240106
-types-tree-sitter-languages==1.10.0.20240201
 langsmith==0.0.87
 pytest-asyncio==0.23.5
 aiohttp==3.9.3

--- a/src/seer/automation/autofix/autofix.py
+++ b/src/seer/automation/autofix/autofix.py
@@ -208,6 +208,7 @@ class Autofix:
                     pr_url=pr.pr_url,
                     repo_name=f"{pr.repo.owner}/{pr.repo.name}",
                     pr_number=pr.pr_number,
+                    diff=pr.diff,
                     usage=self.usage,
                 )
                 self.event_manager.send_autofix_complete(output)
@@ -307,6 +308,7 @@ class Autofix:
                             owner=codebase.repo_client.repo_owner,
                             name=codebase.repo_client.repo_name,
                         ),
+                        diff=codebase.get_file_patches(),
                     )
                 )
 

--- a/src/seer/automation/autofix/models.py
+++ b/src/seer/automation/autofix/models.py
@@ -4,8 +4,8 @@ from typing import Annotated, Any, Literal, Optional
 
 from pydantic import BaseModel, Field, field_validator
 
-from seer.automation.models import FilePatch
 from seer.automation.agent.models import Usage
+from seer.automation.models import FilePatch
 from seer.generator import Examples
 
 
@@ -231,6 +231,7 @@ class PullRequestResult(BaseModel):
     repo: RepoDefinition
     diff: list[FilePatch]
 
+
 class Step(BaseModel):
     id: str
     title: str
@@ -295,4 +296,3 @@ class AutofixContinuation(BaseModel):
                             substep.status = AutofixStatus.ERROR
                         if substep.status == AutofixStatus.PENDING:
                             substep.status = AutofixStatus.CANCELLED
-

--- a/src/seer/automation/autofix/models.py
+++ b/src/seer/automation/autofix/models.py
@@ -4,6 +4,7 @@ from typing import Annotated, Any, Literal, Optional
 
 from pydantic import BaseModel, Field, field_validator
 
+from seer.automation.models import FilePatch
 from seer.automation.agent.models import Usage
 from seer.generator import Examples
 
@@ -37,38 +38,6 @@ class AutofixStatus(enum.Enum):
     @classmethod
     def terminal(cls) -> "frozenset[AutofixStatus]":
         return frozenset((cls.COMPLETED, cls.ERROR, cls.CANCELLED))
-
-
-class FileChange(BaseModel):
-    change_type: Literal["create", "edit", "delete"]
-    path: str
-    reference_snippet: Optional[str] = None
-    new_snippet: Optional[str] = None
-    description: Optional[str] = None
-
-    def apply(self, file_contents: str | None) -> str | None:
-        if self.change_type == "create":
-            if file_contents is not None:
-                raise FileChangeError("Cannot create a file that already exists.")
-            if self.new_snippet is None:
-                raise FileChangeError("New snippet must be provided for creating a file.")
-            return self.new_snippet
-
-        if file_contents is None:
-            raise FileChangeError("File contents must be provided for non-create operations.")
-
-        if self.change_type == "edit":
-            if self.new_snippet is None:
-                raise FileChangeError("New snippet must be provided for editing a file.")
-            if self.reference_snippet is None:
-                raise FileChangeError("Reference snippet must be provided for editing a file.")
-            return file_contents.replace(self.reference_snippet, self.new_snippet)
-
-        # Delete
-        if self.reference_snippet is None:
-            return None
-
-        return file_contents.replace(self.reference_snippet, "")
 
 
 class PlanStep(BaseModel):
@@ -248,6 +217,7 @@ class AutofixOutput(BaseModel):
     pr_url: str
     pr_number: int
     repo_name: str
+    diff: Optional[list[FilePatch]] = []
     usage: Usage
 
 
@@ -259,7 +229,7 @@ class PullRequestResult(BaseModel):
     pr_number: int
     pr_url: str
     repo: RepoDefinition
-
+    diff: list[FilePatch]
 
 class Step(BaseModel):
     id: str
@@ -325,3 +295,4 @@ class AutofixContinuation(BaseModel):
                             substep.status = AutofixStatus.ERROR
                         if substep.status == AutofixStatus.PENDING:
                             substep.status = AutofixStatus.CANCELLED
+

--- a/src/seer/automation/autofix/tools.py
+++ b/src/seer/automation/autofix/tools.py
@@ -8,10 +8,10 @@ from seer.automation.agent.client import GptClient
 from seer.automation.agent.models import Message, Usage
 from seer.automation.agent.tools import FunctionTool
 from seer.automation.autofix.autofix_context import AutofixContext
-from seer.automation.autofix.models import FileChange
 from seer.automation.autofix.prompts import ExecutionPrompts
 from seer.automation.autofix.utils import find_original_snippet
 from seer.automation.codebase.codebase_index import CodebaseIndex
+from seer.automation.models import FileChange
 
 logger = logging.getLogger("autofix")
 

--- a/src/seer/automation/codebase/ast.py
+++ b/src/seer/automation/codebase/ast.py
@@ -5,8 +5,8 @@ from tree_sitter import Node, Tree
 class AstDeclaration(BaseModel):
     id: int
     indent_start_byte: int
-    declaration_byte_start: int
-    declaration_byte_end: int
+    declaration_start_byte: int
+    declaration_end_byte: int
 
     declaration_nodes: list[Node]
 
@@ -24,8 +24,8 @@ class AstDeclaration(BaseModel):
     def to_str(self, root_node: Node, include_indent=False) -> str:
         return root_node.text[
             (
-                self.indent_start_byte if include_indent else self.declaration_byte_start
-            ) : self.declaration_byte_end
+                self.indent_start_byte if include_indent else self.declaration_start_byte
+            ) : self.declaration_end_byte
         ].decode("utf-8")
 
 
@@ -99,13 +99,14 @@ def extract_declaration(node: Node, root_node: Node, language: str) -> AstDeclar
         index_of_colon, _ = result
 
         indent_start_byte = get_indent_start_byte(node.children[0], root_node)
+        declaration_start_byte = node.children[0].start_byte
         declaration_end_byte = node.children[index_of_colon].end_byte
 
         return AstDeclaration(
             id=node.id,
             indent_start_byte=indent_start_byte,
-            declaration_byte_start=node.children[index_of_colon + 1].start_byte,
-            declaration_byte_end=declaration_end_byte,
+            declaration_start_byte=declaration_start_byte,
+            declaration_end_byte=declaration_end_byte,
             declaration_nodes=node.children[: index_of_colon + 1],
         )
 
@@ -133,8 +134,8 @@ def extract_declaration(node: Node, root_node: Node, language: str) -> AstDeclar
             return AstDeclaration(
                 id=node.id,
                 indent_start_byte=indent_start_byte,
-                declaration_byte_start=declaration_start_byte,
-                declaration_byte_end=declaration_end_byte,
+                declaration_start_byte=declaration_start_byte,
+                declaration_end_byte=declaration_end_byte,
                 declaration_nodes=declaration_nodes,
             )
     return None

--- a/src/seer/automation/codebase/ast.py
+++ b/src/seer/automation/codebase/ast.py
@@ -1,0 +1,147 @@
+from pydantic import BaseModel
+from tree_sitter import Node, Tree
+
+
+class AstDeclaration(BaseModel):
+    id: int
+    declaration_byte_start: int
+    declaration_byte_end: int
+    content_indent: str
+
+    declaration_nodes: list[Node]
+
+    class Config:
+        arbitrary_types_allowed = True
+
+    def __eq__(self, other):
+        if isinstance(other, AstDeclaration):
+            return self.id == other.id
+        return False
+
+    def __hash__(self):
+        return self.id
+
+    def to_str(self, root_node: Node) -> str:
+        return root_node.text[self.declaration_byte_start : self.declaration_byte_end].decode(
+            "utf-8"
+        )
+
+
+def get_indent_start_byte(node: Node, root: Node) -> int:
+    if node.start_byte == 0:
+        return 0
+    newline_index = root.text.rfind(b"\n", 0, node.start_byte)
+    if newline_index == -1:
+        # No newline character found, return start_byte
+        return node.start_byte
+    line_start_byte = newline_index + 1
+    # Check if there are only spaces or tabs before the newline
+    if all(c in b" \t" for c in root.text[line_start_byte : node.start_byte]):
+        return line_start_byte
+    else:
+        return node.start_byte
+
+
+def index_with_node_type(node_type: str, node: Node, recursive=True):
+    for i, child in enumerate(node.children):
+        if child.type == node_type:
+            return i, child
+        if recursive:
+            descendant_result = index_with_node_type(node_type, child, recursive=True)
+            if descendant_result:
+                return i, descendant_result[1]
+    return None
+
+
+def first_child_with_type(node_types: set[str], node: Node):
+    for child in node.children:
+        if child.type in node_types:
+            return child
+    return None
+
+
+def supports_parent_declarations(language: str) -> bool:
+    return language in ["python", "javascript", "typescript", "jsx", "tsx"]
+
+
+def node_is_a_declaration(node: Node, language: str) -> bool:
+    if language == "python":
+        return node.type.endswith("_definition") or any(
+            [child.type == "block" for child in node.children]
+        )  # is a definition type node or has an immediate block child
+    if language in ["javascript", "typescript", "jsx", "tsx"]:
+        return node.type in [
+            "class_declaration",
+            "method_definition",
+            "function_declaration",
+            "lexical_declaration",
+        ] or any(
+            [child.type == "statement_block" for child in node.children]
+        )  # is a definition type node or has an immediate block child
+    return False
+
+
+def find_first_parent_declaration(node: Node, language: str):
+    parent = node.parent
+    while parent:
+        if node_is_a_declaration(parent, language):
+            return parent
+
+
+def extract_declaration(node: Node, root_node: Node, language: str) -> AstDeclaration | None:
+    if language == "python":
+        result = index_with_node_type(":", node, recursive=False)
+        if result is None:
+            # Handle the case where there is no colon
+            return None
+        index_of_colon, _ = result
+
+        declaration_start_byte = get_indent_start_byte(node.children[0], root_node)
+        declaration_end_byte = node.children[index_of_colon].end_byte
+        content_indent = root_node.text[
+            get_indent_start_byte(node.children[index_of_colon + 1], root_node) : node.children[
+                index_of_colon + 1
+            ].start_byte
+        ].decode("utf-8")
+
+        return AstDeclaration(
+            id=node.id,
+            declaration_byte_start=declaration_start_byte,
+            declaration_byte_end=declaration_end_byte,
+            content_indent=content_indent,
+            declaration_nodes=node.children[: index_of_colon + 1],
+        )
+
+    if language in ["javascript", "typescript", "jsx", "tsx"]:
+        child = first_child_with_type(set(("class_body", "statement_block")), node)
+        if child is None:
+            return None
+
+        result = index_with_node_type("{", child, recursive=True)
+        if result is None:
+            return None
+        child_index, bracket_node = result
+
+        if bracket_node.next_sibling:
+            declaration_start_byte = get_indent_start_byte(node.children[0], root_node)
+            declaration_end_byte = bracket_node.end_byte
+            content_indent = root_node.text[
+                get_indent_start_byte(
+                    bracket_node.next_sibling, root_node
+                ) : bracket_node.next_sibling.start_byte
+            ].decode("utf-8")
+
+            declaration_nodes = node.children[:child_index]
+            if bracket_node.parent:
+                # TODO: There probably are more levels to this...
+                bracket_node_index = bracket_node.parent.children.index(bracket_node)
+                declaration_nodes += bracket_node.parent.children[: bracket_node_index + 1]
+
+            return AstDeclaration(
+                id=node.id,
+                declaration_byte_start=declaration_start_byte,
+                declaration_byte_end=declaration_end_byte,
+                content_indent=content_indent,
+                declaration_nodes=declaration_nodes,
+            )
+    return None

--- a/src/seer/automation/codebase/codebase_index.py
+++ b/src/seer/automation/codebase/codebase_index.py
@@ -574,6 +574,8 @@ class CodebaseIndex:
                             )
                             section_header = (
                                 declaration.to_str(tree.root_node, include_indent=False)
+                                .splitlines()[0]
+                                .strip()
                                 if declaration
                                 else section_header
                             )

--- a/src/seer/automation/codebase/codebase_index.py
+++ b/src/seer/automation/codebase/codebase_index.py
@@ -551,9 +551,9 @@ class CodebaseIndex:
                 section_header = hunk.section_header
                 if tree and document:
                     line_numbers = [
-                        line.source_line_no
+                        line.target_line_no
                         for line in lines
-                        if line.line_type != " " and line.source_line_no is not None
+                        if line.line_type != " " and line.target_line_no is not None
                     ]
                     first_line_no = line_numbers[0] if line_numbers else None
                     last_line_no = line_numbers[-1] if line_numbers else None

--- a/src/seer/automation/codebase/codebase_index.py
+++ b/src/seer/automation/codebase/codebase_index.py
@@ -350,10 +350,10 @@ class CodebaseIndex:
             logger.warning(f"Unsupported language for {path}")
             return None
 
-        document: Document | None = Document(path=path, text=document_content, language=language)
+        document = Document(path=path, text=document_content, language=language)
 
         if not ignore_local_changes:
-            document = self._copy_document_with_local_changes(document)
+            return self._copy_document_with_local_changes(document)
 
         return document
 

--- a/src/seer/automation/codebase/codebase_index.py
+++ b/src/seer/automation/codebase/codebase_index.py
@@ -324,7 +324,7 @@ class CodebaseIndex:
         return self.repo_client.get_file_content(path, sha)
 
     def _copy_document_with_local_changes(self, document: Document) -> Document | None:
-        content = document.text
+        content: str | None = document.text
         # Make sure the changes are applied in order!
         changes = list(filter(lambda x: x.path == document.path, self.file_changes))
         if changes:
@@ -350,7 +350,7 @@ class CodebaseIndex:
             logger.warning(f"Unsupported language for {path}")
             return None
 
-        document = Document(path=path, text=document_content, language=language)
+        document: Document | None = Document(path=path, text=document_content, language=language)
 
         if not ignore_local_changes:
             document = self._copy_document_with_local_changes(document)

--- a/src/seer/automation/codebase/codebase_index.py
+++ b/src/seer/automation/codebase/codebase_index.py
@@ -573,7 +573,7 @@ class CodebaseIndex:
                                 else None
                             )
                             section_header = (
-                                declaration.to_str(tree.root_node)
+                                declaration.to_str(tree.root_node, include_indent=False)
                                 if declaration
                                 else section_header
                             )

--- a/src/seer/automation/codebase/parser.py
+++ b/src/seer/automation/codebase/parser.py
@@ -47,8 +47,10 @@ class TempChunk(BaseModel):
                 {content_indent}...
                 """
             ).format(
-                declaration=declaration.to_str(root),
-                content_indent=declaration.content_indent,
+                declaration=declaration.to_str(root, include_indent=True),
+                content_indent=root.text[
+                    declaration.indent_start_byte : declaration.declaration_byte_start
+                ].decode("utf-8"),
             )
         return context_text
 

--- a/src/seer/automation/codebase/parser.py
+++ b/src/seer/automation/codebase/parser.py
@@ -49,7 +49,7 @@ class TempChunk(BaseModel):
             ).format(
                 declaration=declaration.to_str(root, include_indent=True),
                 content_indent=root.text[
-                    declaration.indent_start_byte : declaration.declaration_byte_start
+                    declaration.indent_start_byte : declaration.declaration_start_byte
                 ].decode("utf-8"),
             )
         return context_text

--- a/src/seer/automation/codebase/parser.py
+++ b/src/seer/automation/codebase/parser.py
@@ -8,68 +8,23 @@ from pydantic import BaseModel
 from sentence_transformers import SentenceTransformer
 from tree_sitter import Node
 
+from seer.automation.codebase.ast import (
+    AstDeclaration,
+    extract_declaration,
+    first_child_with_type,
+    get_indent_start_byte,
+    index_with_node_type,
+    node_is_a_declaration,
+)
 from seer.automation.codebase.models import BaseDocumentChunk, Document
 from seer.utils import class_method_lru_cache
 
 logger = logging.getLogger("autofix")
 
 
-def get_indent_start_byte(node: Node, root: Node) -> int:
-    if node.start_byte == 0:
-        return 0
-    newline_index = root.text.rfind(b"\n", 0, node.start_byte)
-    if newline_index == -1:
-        # No newline character found, return start_byte
-        return node.start_byte
-    line_start_byte = newline_index + 1
-    # Check if there are only spaces or tabs before the newline
-    if all(c in b" \t" for c in root.text[line_start_byte : node.start_byte]):
-        return line_start_byte
-    else:
-        return node.start_byte
-
-
-def index_with_node_type(node_type: str, node: Node, recursive=True):
-    for i, child in enumerate(node.children):
-        if child.type == node_type:
-            return i, child
-        if recursive:
-            descendant_result = index_with_node_type(node_type, child, recursive=True)
-            if descendant_result:
-                return i, descendant_result[1]
-    return None
-
-
-def first_child_with_type(node_types: set[str], node: Node):
-    for child in node.children:
-        if child.type in node_types:
-            return child
-    return None
-
-
-class ParentDeclaration(BaseModel):
-    id: int
-    declaration_byte_start: int
-    declaration_byte_end: int
-    content_indent: str
-
-    declaration_nodes: list[Node]
-
-    class Config:
-        arbitrary_types_allowed = True
-
-    def __eq__(self, other):
-        if isinstance(other, ParentDeclaration):
-            return self.id == other.id
-        return False
-
-    def __hash__(self):
-        return self.id
-
-
 class TempChunk(BaseModel):
     nodes: list[Node]
-    parent_declarations: list[ParentDeclaration]
+    parent_declarations: list[AstDeclaration]
 
     class Config:
         arbitrary_types_allowed = True
@@ -92,9 +47,7 @@ class TempChunk(BaseModel):
                 {content_indent}...
                 """
             ).format(
-                declaration=root.text[
-                    declaration.declaration_byte_start : declaration.declaration_byte_end
-                ].decode("utf-8"),
+                declaration=declaration.to_str(root),
                 content_indent=declaration.content_indent,
             )
         return context_text
@@ -135,7 +88,7 @@ class DocumentParser:
         self,
         node: Node,
         language: str,
-        parent_declarations: list[ParentDeclaration] = [],
+        parent_declarations: list[AstDeclaration] = [],
         root_node: Node | None = None,
         last_end_byte=0,
     ) -> list[TempChunk]:
@@ -173,9 +126,9 @@ class DocumentParser:
             if token_count > self.break_chunks_at:
                 # Recursively chunk the children if the current node is too big or should be chunked
                 parent_declarations_for_children = parent_declarations.copy()
-                is_parent_declaration = self._node_is_a_declaration(children[i], language)
+                is_parent_declaration = node_is_a_declaration(children[i], language)
                 if is_parent_declaration:
-                    declaration = self._extract_declaration(children[i], root_node, language)
+                    declaration = extract_declaration(children[i], root_node, language)
                     if declaration:
                         parent_declarations_for_children.append(declaration)
 
@@ -232,82 +185,6 @@ class DocumentParser:
             ]
 
         return chunks
-
-    def _node_is_a_declaration(self, node: Node, language: str) -> bool:
-        if language == "python":
-            return node.type.endswith("_definition") or any(
-                [child.type == "block" for child in node.children]
-            )  # is a definition type node or has an immediate block child
-        if language in ["javascript", "typescript", "jsx", "tsx"]:
-            return node.type in [
-                "class_declaration",
-                "method_definition",
-                "function_declaration",
-                "lexical_declaration",
-            ] or any(
-                [child.type == "statement_block" for child in node.children]
-            )  # is a definition type node or has an immediate block child
-        return False
-
-    def _extract_declaration(
-        self, node: Node, root_node: Node, language: str
-    ) -> ParentDeclaration | None:
-        if language == "python":
-            result = index_with_node_type(":", node, recursive=False)
-            if result is None:
-                # Handle the case where there is no colon
-                return None
-            index_of_colon, _ = result
-
-            declaration_start_byte = get_indent_start_byte(node.children[0], root_node)
-            declaration_end_byte = node.children[index_of_colon].end_byte
-            content_indent = root_node.text[
-                get_indent_start_byte(node.children[index_of_colon + 1], root_node) : node.children[
-                    index_of_colon + 1
-                ].start_byte
-            ].decode("utf-8")
-
-            return ParentDeclaration(
-                id=node.id,
-                declaration_byte_start=declaration_start_byte,
-                declaration_byte_end=declaration_end_byte,
-                content_indent=content_indent,
-                declaration_nodes=node.children[: index_of_colon + 1],
-            )
-
-        if language in ["javascript", "typescript", "jsx", "tsx"]:
-            child = first_child_with_type(set(("class_body", "statement_block")), node)
-            if child is None:
-                return None
-
-            result = index_with_node_type("{", child, recursive=True)
-            if result is None:
-                return None
-            child_index, bracket_node = result
-
-            if bracket_node.next_sibling:
-                declaration_start_byte = get_indent_start_byte(node.children[0], root_node)
-                declaration_end_byte = bracket_node.end_byte
-                content_indent = root_node.text[
-                    get_indent_start_byte(
-                        bracket_node.next_sibling, root_node
-                    ) : bracket_node.next_sibling.start_byte
-                ].decode("utf-8")
-
-                declaration_nodes = node.children[:child_index]
-                if bracket_node.parent:
-                    # TODO: There probably are more levels to this...
-                    bracket_node_index = bracket_node.parent.children.index(bracket_node)
-                    declaration_nodes += bracket_node.parent.children[: bracket_node_index + 1]
-
-                return ParentDeclaration(
-                    id=node.id,
-                    declaration_byte_start=declaration_start_byte,
-                    declaration_byte_end=declaration_end_byte,
-                    content_indent=content_indent,
-                    declaration_nodes=declaration_nodes,
-                )
-        return None
 
     @class_method_lru_cache(maxsize=16)
     def _get_parser(self, language: str):

--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -13,10 +13,8 @@ from github.GitRef import GitRef
 from github.Repository import Repository
 from unidiff import PatchSet
 
-from seer.automation.agent.models import Usage
-from seer.automation.autofix.models import AutofixUserDetails, FileChange, PlanStep
 from seer.automation.autofix.utils import generate_random_string, sanitize_branch_name
-from seer.automation.models import InitializationError
+from seer.automation.models import FileChange, InitializationError
 from seer.utils import class_method_lru_cache
 
 logger = logging.getLogger("autofix")

--- a/src/seer/automation/models.py
+++ b/src/seer/automation/models.py
@@ -1,2 +1,70 @@
+from typing import List, Literal, Optional
+
+from pydantic import BaseModel
+
+
 class InitializationError(Exception):
     pass
+
+
+class Line(BaseModel):
+    source_line_no: Optional[int] = None
+    target_line_no: Optional[int] = None
+    diff_line_no: Optional[int] = None
+    value: str
+    line_type: Literal[" ", "+", "-"]
+
+
+class Hunk(BaseModel):
+    source_start: int
+    source_length: int
+    target_start: int
+    target_length: int
+    section_header: str
+    lines: List[Line]
+
+
+class FilePatch(BaseModel):
+    type: Literal["A", "M", "D"]
+    path: str
+    added: int
+    removed: int
+    source_file: str
+    target_file: str
+    hunks: List[Hunk]
+
+
+class FileChangeError(Exception):
+    pass
+
+
+class FileChange(BaseModel):
+    change_type: Literal["create", "edit", "delete"]
+    path: str
+    reference_snippet: Optional[str] = None
+    new_snippet: Optional[str] = None
+    description: Optional[str] = None
+
+    def apply(self, file_contents: str | None) -> str | None:
+        if self.change_type == "create":
+            if file_contents is not None and file_contents != "":
+                raise FileChangeError("Cannot create a file that already exists.")
+            if self.new_snippet is None:
+                raise FileChangeError("New snippet must be provided for creating a file.")
+            return self.new_snippet
+
+        if file_contents is None:
+            raise FileChangeError("File contents must be provided for non-create operations.")
+
+        if self.change_type == "edit":
+            if self.new_snippet is None:
+                raise FileChangeError("New snippet must be provided for editing a file.")
+            if self.reference_snippet is None:
+                raise FileChangeError("Reference snippet must be provided for editing a file.")
+            return file_contents.replace(self.reference_snippet, self.new_snippet)
+
+        # Delete
+        if self.reference_snippet is None:
+            return None
+
+        return file_contents.replace(self.reference_snippet, "")

--- a/tests/automation/autofix/test_autofix_tools.py
+++ b/tests/automation/autofix/test_autofix_tools.py
@@ -2,8 +2,8 @@ import textwrap
 import unittest
 from unittest.mock import MagicMock, patch
 
-from seer.automation.autofix.models import FileChange
 from seer.automation.autofix.tools import CodeActionTools
+from seer.automation.models import FileChange
 
 
 class TestReplaceSnippetWith(unittest.TestCase):

--- a/tests/automation/codebase/test_codebase_index.py
+++ b/tests/automation/codebase/test_codebase_index.py
@@ -471,10 +471,12 @@ class TestCodebaseIndexGetFilePatches(unittest.TestCase):
             language="python",
             text=textwrap.dedent(
                 """\
-                def foo():
-                    x = 1 + 1
-                    y = 2 + 2
-                    return x + y"""
+                class foo:
+                    a = 5
+                    def foobar(a: int):
+                        x = 1 + 1
+                        y = 2 + 2
+                        return x + y"""
             ),
         )
 
@@ -502,4 +504,4 @@ class TestCodebaseIndexGetFilePatches(unittest.TestCase):
         self.assertEqual(patches[0].path, "file1.py")
         self.assertEqual(patches[0].type, "M")
         self.assertEqual(len(patches[0].hunks), 1)
-        self.assertEqual(patches[0].hunks[0].section_header, "def foo():")
+        self.assertEqual(patches[0].hunks[0].section_header, "def foobar(a: int):")

--- a/tests/automation/codebase/test_codebase_index.py
+++ b/tests/automation/codebase/test_codebase_index.py
@@ -491,13 +491,15 @@ class TestCodebaseIndexGetFilePatches(unittest.TestCase):
                 change_type="edit",
                 path="file1.py",
                 reference_snippet="""    y = 2 + 3""",
-                new_snippet="""    y = 2 + 4 # yes\n    z = 3 + 3""",
+                new_snippet="""    y = 2 + 4 # yes\n        z = 3 + 3""",
             ),
         ]
 
         # Execute
         patches = self.codebase_index.get_file_patches()
         patches.sort(key=lambda p: p.path)  # Sort patches by path to make the test deterministic
+
+        print(patches)
 
         # Assert
         self.assertEqual(len(patches), 1)

--- a/tests/automation/codebase/test_codebase_index.py
+++ b/tests/automation/codebase/test_codebase_index.py
@@ -1,3 +1,4 @@
+import textwrap
 import unittest
 import uuid
 from unittest.mock import MagicMock, patch
@@ -5,7 +6,13 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 
 from seer.automation.codebase.codebase_index import CodebaseIndex
-from seer.automation.codebase.models import BaseDocumentChunk, EmbeddedDocumentChunk, RepositoryInfo
+from seer.automation.codebase.models import (
+    BaseDocumentChunk,
+    Document,
+    EmbeddedDocumentChunk,
+    RepositoryInfo,
+)
+from seer.automation.models import FileChange, FilePatch, Hunk, Line
 from seer.db import DbDocumentChunk, DbRepositoryInfo, Session
 
 
@@ -312,3 +319,150 @@ class TestCodebaseIndexUpdate(unittest.TestCase):
             chunks = session.query(DbDocumentChunk).order_by("index").all()
             self.assertEqual(len(chunks), 1)
             self.assertEqual(chunks[0].hash, "file1.1")
+
+
+class TestCodebaseIndexGetFilePatches(unittest.TestCase):
+    def setUp(self):
+        self.organization = 1
+        self.project = 1
+        self.repo_definition = MagicMock()
+        self.run_id = uuid.uuid4()
+        self.repo_info = RepositoryInfo(
+            id=1, organization=1, project=1, provider="github", external_slug="test/repo", sha="sha"
+        )
+        self.repo_client = MagicMock()
+        self.repo_client.load_repo_to_tmp_dir.return_value = ("tmp_dir", "tmp_dir/repo")
+        self.codebase_index = CodebaseIndex(
+            self.organization, self.project, self.repo_client, self.repo_info, self.run_id
+        )
+        self.mock_get_document = MagicMock()
+        self.codebase_index.get_document = self.mock_get_document
+
+    def test_get_file_patches(self):
+        def get_document_mock(file_path, ignore_local_changes=False):
+            if file_path == "file1.py":
+                return Document(
+                    path="file1.py",
+                    language="python",
+                    text=textwrap.dedent(
+                        """\
+                        def foo():
+                            x = 1 + 1
+                            y = 2 + 2
+                            return x + y"""
+                    ),
+                )
+            elif file_path == "file2.py":
+                return None
+            elif file_path == "file3.py":
+                return Document(
+                    path="file3.py",
+                    language="python",
+                    text=textwrap.dedent(
+                        """\
+                        def baz():
+                            a = 1 + 5
+                            return 'baz'
+                        """
+                    ),
+                )
+
+        self.mock_get_document.side_effect = get_document_mock
+
+        self.codebase_index.file_changes = [
+            FileChange(
+                change_type="edit",
+                path="file1.py",
+                reference_snippet="""    y = 2 + 2""",
+                new_snippet="""    y = 2 + 3""",
+            ),
+            FileChange(
+                change_type="edit",
+                path="file1.py",
+                reference_snippet="""    y = 2 + 3""",
+                new_snippet="""    y = 2 + 4 # yes\n    z = 3 + 3""",
+            ),
+            FileChange(
+                change_type="create",
+                path="file2.py",
+                new_snippet=textwrap.dedent(
+                    """\
+                    def bar():
+                        return 'bar'
+                    """
+                ),
+            ),
+            FileChange(
+                change_type="delete",
+                path="file3.py",
+                reference_snippet=textwrap.dedent("""    a = 1 + 5\n"""),
+            ),
+        ]
+
+        # Execute
+        patches = self.codebase_index.get_file_patches()
+        patches.sort(key=lambda p: p.path)  # Sort patches by path to make the test deterministic
+
+        # Assert
+        self.assertEqual(len(patches), 3)
+        self.assertEqual(patches[0].path, "file1.py")
+        self.assertEqual(patches[0].type, "M")
+        self.assertEqual(patches[0].added, 2)
+        self.assertEqual(patches[0].removed, 1)
+        self.assertEqual(patches[0].source_file, "file1.py")
+        self.assertEqual(patches[0].target_file, "file1.py")
+        self.assertEqual(len(patches[0].hunks), 1)
+
+        self.assertEqual(patches[1].path, "file2.py")
+        self.assertEqual(patches[1].type, "A")
+        self.assertEqual(patches[1].added, 2)
+        self.assertEqual(patches[1].removed, 0)
+        self.assertEqual(patches[1].source_file, "/dev/null")
+        self.assertEqual(patches[1].target_file, "file2.py")
+        self.assertEqual(len(patches[1].hunks), 1)
+
+        self.assertEqual(patches[2].path, "file3.py")
+        self.assertEqual(patches[2].type, "M")
+        self.assertEqual(patches[2].added, 1)
+        self.assertEqual(patches[2].removed, 2)
+        self.assertEqual(patches[2].source_file, "file3.py")
+        self.assertEqual(patches[2].target_file, "file3.py")
+        self.assertEqual(len(patches[2].hunks), 1)
+
+    def test_get_file_patches_with_full_delete(self):
+        self.mock_get_document.return_value = Document(
+            path="file_to_delete.py",
+            language="python",
+            text=textwrap.dedent(
+                """\
+                def baz():
+                    a = 1 + 5
+                    return 'baz'
+                """
+            ),
+        )
+        file_change = FileChange(
+            change_type="delete",
+            path="file_to_delete.py",
+            reference_snippet=textwrap.dedent(
+                """\
+                def baz():
+                    a = 1 + 5
+                    return 'baz'
+                """
+            ),
+            new_snippet=None,
+        )
+        self.codebase_index.file_changes = [file_change]
+
+        # Execute
+        patches = self.codebase_index.get_file_patches()
+
+        # Assert
+        self.assertEqual(len(patches), 1)
+        self.assertEqual(patches[0].path, "file_to_delete.py")
+        self.assertEqual(patches[0].type, "D")
+        self.assertEqual(patches[0].added, 0)
+        self.assertEqual(patches[0].removed, 3)
+        self.assertEqual(patches[0].source_file, "file_to_delete.py")
+        self.assertEqual(patches[0].target_file, "/dev/null")

--- a/tests/automation/codebase/test_parser.py
+++ b/tests/automation/codebase/test_parser.py
@@ -5,7 +5,7 @@ from sentence_transformers import SentenceTransformer
 from tree_sitter import Node, Parser
 
 from seer.automation.codebase.models import BaseDocumentChunk
-from seer.automation.codebase.parser import Document, DocumentParser, ParentDeclaration, TempChunk
+from seer.automation.codebase.parser import Document, DocumentParser
 
 
 class TestDocumentParser(unittest.TestCase):


### PR DESCRIPTION
Computes a diff of the combined file changes of an autofix run. Does not use the github API, this way we can use this to generate a diff for a set of file changes without needing to interact with github at all.

In conjunction with https://github.com/getsentry/sentry/pull/66522

<img width="1382" alt="Screenshot 2024-03-08 at 1 27 29 PM" src="https://github.com/getsentry/timeseries-analysis-service/assets/30991498/7e8a7bb4-3588-4b75-889c-154c6256bc23">
